### PR TITLE
Don't use s:get_indent()

### DIFF
--- a/autoload/caw.vim
+++ b/autoload/caw.vim
@@ -802,11 +802,9 @@ function! s:caw_i_comment_normal(lnum, ...) dict "{{{
         let after  = min_indent_num ==# 0 ? line : line[min_indent_num :]
         call setline(a:lnum, before . cmt . s:get_var('caw_sp_i') . after)
     elseif line =~# '^\s*$'
-        let indent = s:get_indent(a:lnum)
-        call setline(a:lnum, indent . cmt . s:get_var('caw_sp_i'))
-        if startinsert
-            startinsert!
-        endif
+        " Delete the current line and then do "gcO".
+        silent delete _
+        call s:caw.jump['comment-prev']('n')
     else
         let indent = s:get_inserted_indent(a:lnum)
         let line = substitute(getline(a:lnum), '^[ \t]\+', '', '')


### PR DESCRIPTION
先のパッチの続きです。
s:get_indent() が使われている箇所を調べたら後は s:caw_i_comment_normal() における、
現在行が空行のケース1件だけで、そこは s:caw_jump_comment() で処理を代用できるので
そうしてみました。やっているのは

現在行を削除してから "gcO"

です。

feedkeys() を使うのをやめたのはコマンドの実行が関数を抜けてからになるせいか、
行を削除しているのが一瞬見えてしまうからです。

挿入モードへの移行は normal! から一発でやりたかったのですが、空白の扱いが難しかったので
いったん抜けてから setline() で空白を付加、startinsert! するようにしました。

この変更で s:get_indent(), s:get_indent_num() を使用している箇所がなくなりましたが、関数の定義は削除していません。
