### PR TITLE
eRuby のブロックコメントの修正

### DIFF
--- a/autoload/caw.vim
+++ b/autoload/caw.vim
@@ -576,7 +576,7 @@ function! s:comments.wrap_oneline.get_comment_builtin() "{{{
     \   'dot': ['/*', '*/'],
     \   'dtml': ['<dtml-comment>', '</dtml-comment>'],
     \   'dylan': ['/*', '*/'],
-    \   'eruby': ['<!--', '-->'],
+    \   'eruby': ['<%#', '%>'],
     \   'fx': ['/*', '*/'],
     \   'genshi': ['<!--', '-->'],
     \   'groovy': ['/*', '*/'],


### PR DESCRIPTION
現在の caw.vim でのコメントは <!-- --> になっていますが，これは html
のコメントであって eRuby に由来するものではありません．
ERuby で <!-- --> をコメントに使うと 生成した html
にコメントが残ってしまいますし，そもそも html 以外のものに eRuby
を利用した場合に正しく機能しません．
従って，eRuby 本来のコメントである <%# %> に修正しました．
