### PR TITLE
Fix duplicate entries in b:undo_ftplugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ before_script:
   - git clone https://github.com/syngan/vim-vimlint /tmp/vim-vimlint
   - git clone https://github.com/ynkdir/vim-vimlparser /tmp/vim-vimlparser
   - git clone https://github.com/kannokanno/vmock /tmp/vmock
-  - git clone https://github.com/thinca/vim-themis --branch v1.5 --single-branch --depth 1 /tmp/vim-themis
+  - git clone https://github.com/thinca/vim-themis --branch v1.5.1 --single-branch --depth 1 /tmp/vim-themis
 
 script:
   - which -a vim

--- a/after/ftplugin/aap/caw.vim
+++ b/after/ftplugin/aap/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/aap/caw.vim
+++ b/after/ftplugin/aap/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/abc/caw.vim
+++ b/after/ftplugin/abc/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/abc/caw.vim
+++ b/after/ftplugin/abc/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/acedb/caw.vim
+++ b/after/ftplugin/acedb/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/acedb/caw.vim
+++ b/after/ftplugin/acedb/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/actionscript/caw.vim
+++ b/after/ftplugin/actionscript/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/actionscript/caw.vim
+++ b/after/ftplugin/actionscript/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ada/caw.vim
+++ b/after/ftplugin/ada/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ada/caw.vim
+++ b/after/ftplugin/ada/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ahdl/caw.vim
+++ b/after/ftplugin/ahdl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ahdl/caw.vim
+++ b/after/ftplugin/ahdl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ahk/caw.vim
+++ b/after/ftplugin/ahk/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ahk/caw.vim
+++ b/after/ftplugin/ahk/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/amiga/caw.vim
+++ b/after/ftplugin/amiga/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/amiga/caw.vim
+++ b/after/ftplugin/amiga/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/aml/caw.vim
+++ b/after/ftplugin/aml/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '/*'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/aml/caw.vim
+++ b/after/ftplugin/aml/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '/*'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ampl/caw.vim
+++ b/after/ftplugin/ampl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ampl/caw.vim
+++ b/after/ftplugin/ampl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/apache/caw.vim
+++ b/after/ftplugin/apache/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/apache/caw.vim
+++ b/after/ftplugin/apache/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/apachestyle/caw.vim
+++ b/after/ftplugin/apachestyle/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/apachestyle/caw.vim
+++ b/after/ftplugin/apachestyle/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/applescript/caw.vim
+++ b/after/ftplugin/applescript/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/applescript/caw.vim
+++ b/after/ftplugin/applescript/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asciidoc/caw.vim
+++ b/after/ftplugin/asciidoc/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asciidoc/caw.vim
+++ b/after/ftplugin/asciidoc/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asm/caw.vim
+++ b/after/ftplugin/asm/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asm/caw.vim
+++ b/after/ftplugin/asm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asm68k/caw.vim
+++ b/after/ftplugin/asm68k/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asm68k/caw.vim
+++ b/after/ftplugin/asm68k/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asn/caw.vim
+++ b/after/ftplugin/asn/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asn/caw.vim
+++ b/after/ftplugin/asn/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/aspvbs/caw.vim
+++ b/after/ftplugin/aspvbs/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ''''
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/aspvbs/caw.vim
+++ b/after/ftplugin/aspvbs/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ''''
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asterisk/caw.vim
+++ b/after/ftplugin/asterisk/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asterisk/caw.vim
+++ b/after/ftplugin/asterisk/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asy/caw.vim
+++ b/after/ftplugin/asy/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/asy/caw.vim
+++ b/after/ftplugin/asy/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/atlas/caw.vim
+++ b/after/ftplugin/atlas/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = 'C'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/atlas/caw.vim
+++ b/after/ftplugin/atlas/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = 'C'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/autohotkey/caw.vim
+++ b/after/ftplugin/autohotkey/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/autohotkey/caw.vim
+++ b/after/ftplugin/autohotkey/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/autoit/caw.vim
+++ b/after/ftplugin/autoit/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/autoit/caw.vim
+++ b/after/ftplugin/autoit/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ave/caw.vim
+++ b/after/ftplugin/ave/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ''''
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ave/caw.vim
+++ b/after/ftplugin/ave/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ''''
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/awk/caw.vim
+++ b/after/ftplugin/awk/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/awk/caw.vim
+++ b/after/ftplugin/awk/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/basic/caw.vim
+++ b/after/ftplugin/basic/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ''''
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/basic/caw.vim
+++ b/after/ftplugin/basic/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ''''
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/bbx/caw.vim
+++ b/after/ftplugin/bbx/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/bbx/caw.vim
+++ b/after/ftplugin/bbx/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/bc/caw.vim
+++ b/after/ftplugin/bc/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/bc/caw.vim
+++ b/after/ftplugin/bc/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/bib/caw.vim
+++ b/after/ftplugin/bib/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/bib/caw.vim
+++ b/after/ftplugin/bib/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/bindzone/caw.vim
+++ b/after/ftplugin/bindzone/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/bindzone/caw.vim
+++ b/after/ftplugin/bindzone/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/bst/caw.vim
+++ b/after/ftplugin/bst/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/bst/caw.vim
+++ b/after/ftplugin/bst/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/btm/caw.vim
+++ b/after/ftplugin/btm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '::'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/btm/caw.vim
+++ b/after/ftplugin/btm/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '::'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/c/caw.vim
+++ b/after/ftplugin/c/caw.vim
@@ -3,21 +3,18 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 let b:caw_wrap_multiline_comment = {'right': '*/', 'bottom': '*', 'left': '/*', 'top': '*'}
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/c/caw.vim
+++ b/after/ftplugin/c/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 let b:caw_wrap_multiline_comment = {'right': '*/', 'bottom': '*', 'left': '/*', 'top': '*'}
@@ -12,6 +16,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/calibre/caw.vim
+++ b/after/ftplugin/calibre/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/calibre/caw.vim
+++ b/after/ftplugin/calibre/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/caos/caw.vim
+++ b/after/ftplugin/caos/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '*'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/caos/caw.vim
+++ b/after/ftplugin/caos/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '*'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/catalog/caw.vim
+++ b/after/ftplugin/catalog/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/catalog/caw.vim
+++ b/after/ftplugin/catalog/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cfg/caw.vim
+++ b/after/ftplugin/cfg/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cfg/caw.vim
+++ b/after/ftplugin/cfg/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cg/caw.vim
+++ b/after/ftplugin/cg/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cg/caw.vim
+++ b/after/ftplugin/cg/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ch/caw.vim
+++ b/after/ftplugin/ch/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ch/caw.vim
+++ b/after/ftplugin/ch/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cl/caw.vim
+++ b/after/ftplugin/cl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cl/caw.vim
+++ b/after/ftplugin/cl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/clean/caw.vim
+++ b/after/ftplugin/clean/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/clean/caw.vim
+++ b/after/ftplugin/clean/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/clipper/caw.vim
+++ b/after/ftplugin/clipper/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/clipper/caw.vim
+++ b/after/ftplugin/clipper/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/clojure/caw.vim
+++ b/after/ftplugin/clojure/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/clojure/caw.vim
+++ b/after/ftplugin/clojure/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cmake/caw.vim
+++ b/after/ftplugin/cmake/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cmake/caw.vim
+++ b/after/ftplugin/cmake/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/conf/caw.vim
+++ b/after/ftplugin/conf/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/conf/caw.vim
+++ b/after/ftplugin/conf/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/config/caw.vim
+++ b/after/ftplugin/config/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/config/caw.vim
+++ b/after/ftplugin/config/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/conkyrc/caw.vim
+++ b/after/ftplugin/conkyrc/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/conkyrc/caw.vim
+++ b/after/ftplugin/conkyrc/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cpp/caw.vim
+++ b/after/ftplugin/cpp/caw.vim
@@ -3,21 +3,18 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 let b:caw_wrap_multiline_comment = {'right': '*/', 'bottom': '*', 'left': '/*', 'top': '*'}
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cpp/caw.vim
+++ b/after/ftplugin/cpp/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 let b:caw_wrap_multiline_comment = {'right': '*/', 'bottom': '*', 'left': '/*', 'top': '*'}
@@ -12,6 +16,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/crontab/caw.vim
+++ b/after/ftplugin/crontab/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/crontab/caw.vim
+++ b/after/ftplugin/crontab/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cs/caw.vim
+++ b/after/ftplugin/cs/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cs/caw.vim
+++ b/after/ftplugin/cs/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/csp/caw.vim
+++ b/after/ftplugin/csp/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/csp/caw.vim
+++ b/after/ftplugin/csp/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cterm/caw.vim
+++ b/after/ftplugin/cterm/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '*'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cterm/caw.vim
+++ b/after/ftplugin/cterm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '*'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cucumber/caw.vim
+++ b/after/ftplugin/cucumber/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cucumber/caw.vim
+++ b/after/ftplugin/cucumber/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cvs/caw.vim
+++ b/after/ftplugin/cvs/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = 'CVS:'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/cvs/caw.vim
+++ b/after/ftplugin/cvs/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = 'CVS:'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/d/caw.vim
+++ b/after/ftplugin/d/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/d/caw.vim
+++ b/after/ftplugin/d/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dakota/caw.vim
+++ b/after/ftplugin/dakota/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dakota/caw.vim
+++ b/after/ftplugin/dakota/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dcl/caw.vim
+++ b/after/ftplugin/dcl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '$!'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dcl/caw.vim
+++ b/after/ftplugin/dcl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '$!'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/debcontrol/caw.vim
+++ b/after/ftplugin/debcontrol/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/debcontrol/caw.vim
+++ b/after/ftplugin/debcontrol/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/debsources/caw.vim
+++ b/after/ftplugin/debsources/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/debsources/caw.vim
+++ b/after/ftplugin/debsources/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/def/caw.vim
+++ b/after/ftplugin/def/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/def/caw.vim
+++ b/after/ftplugin/def/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/desktop/caw.vim
+++ b/after/ftplugin/desktop/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/desktop/caw.vim
+++ b/after/ftplugin/desktop/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dhcpd/caw.vim
+++ b/after/ftplugin/dhcpd/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dhcpd/caw.vim
+++ b/after/ftplugin/dhcpd/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/diff/caw.vim
+++ b/after/ftplugin/diff/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/diff/caw.vim
+++ b/after/ftplugin/diff/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/django/caw.vim
+++ b/after/ftplugin/django/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/django/caw.vim
+++ b/after/ftplugin/django/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dns/caw.vim
+++ b/after/ftplugin/dns/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dns/caw.vim
+++ b/after/ftplugin/dns/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/docbk/caw.vim
+++ b/after/ftplugin/docbk/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/docbk/caw.vim
+++ b/after/ftplugin/docbk/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dosbatch/caw.vim
+++ b/after/ftplugin/dosbatch/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = 'REM'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dosbatch/caw.vim
+++ b/after/ftplugin/dosbatch/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = 'REM'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dosini/caw.vim
+++ b/after/ftplugin/dosini/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dosini/caw.vim
+++ b/after/ftplugin/dosini/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dot/caw.vim
+++ b/after/ftplugin/dot/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dot/caw.vim
+++ b/after/ftplugin/dot/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dracula/caw.vim
+++ b/after/ftplugin/dracula/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dracula/caw.vim
+++ b/after/ftplugin/dracula/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dsl/caw.vim
+++ b/after/ftplugin/dsl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dsl/caw.vim
+++ b/after/ftplugin/dsl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dtml/caw.vim
+++ b/after/ftplugin/dtml/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<dtml-comment>', '</dtml-comment>']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dtml/caw.vim
+++ b/after/ftplugin/dtml/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<dtml-comment>', '</dtml-comment>']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dylan/caw.vim
+++ b/after/ftplugin/dylan/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/dylan/caw.vim
+++ b/after/ftplugin/dylan/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ebuild/caw.vim
+++ b/after/ftplugin/ebuild/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ebuild/caw.vim
+++ b/after/ftplugin/ebuild/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ecd/caw.vim
+++ b/after/ftplugin/ecd/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ecd/caw.vim
+++ b/after/ftplugin/ecd/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/eclass/caw.vim
+++ b/after/ftplugin/eclass/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/eclass/caw.vim
+++ b/after/ftplugin/eclass/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/eiffel/caw.vim
+++ b/after/ftplugin/eiffel/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/eiffel/caw.vim
+++ b/after/ftplugin/eiffel/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/elf/caw.vim
+++ b/after/ftplugin/elf/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ''''
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/elf/caw.vim
+++ b/after/ftplugin/elf/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ''''
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/elm/caw.vim
+++ b/after/ftplugin/elm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 let b:caw_wrap_oneline_comment = ['{-', '-}']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/elm/caw.vim
+++ b/after/ftplugin/elm/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 let b:caw_wrap_oneline_comment = ['{-', '-}']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/elmfilt/caw.vim
+++ b/after/ftplugin/elmfilt/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/elmfilt/caw.vim
+++ b/after/ftplugin/elmfilt/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/erlang/caw.vim
+++ b/after/ftplugin/erlang/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/erlang/caw.vim
+++ b/after/ftplugin/erlang/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/eruby/caw.vim
+++ b/after/ftplugin/eruby/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<%#', '%>']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/eruby/caw.vim
+++ b/after/ftplugin/eruby/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<%#', '%>']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/expect/caw.vim
+++ b/after/ftplugin/expect/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/expect/caw.vim
+++ b/after/ftplugin/expect/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/exports/caw.vim
+++ b/after/ftplugin/exports/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/exports/caw.vim
+++ b/after/ftplugin/exports/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/factor/caw.vim
+++ b/after/ftplugin/factor/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '!'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/factor/caw.vim
+++ b/after/ftplugin/factor/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '!'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/fgl/caw.vim
+++ b/after/ftplugin/fgl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/fgl/caw.vim
+++ b/after/ftplugin/fgl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/focexec/caw.vim
+++ b/after/ftplugin/focexec/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '-*'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/focexec/caw.vim
+++ b/after/ftplugin/focexec/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '-*'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/form/caw.vim
+++ b/after/ftplugin/form/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '*'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/form/caw.vim
+++ b/after/ftplugin/form/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '*'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/foxpro/caw.vim
+++ b/after/ftplugin/foxpro/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '*'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/foxpro/caw.vim
+++ b/after/ftplugin/foxpro/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '*'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/fstab/caw.vim
+++ b/after/ftplugin/fstab/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/fstab/caw.vim
+++ b/after/ftplugin/fstab/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/fvwm/caw.vim
+++ b/after/ftplugin/fvwm/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/fvwm/caw.vim
+++ b/after/ftplugin/fvwm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/fx/caw.vim
+++ b/after/ftplugin/fx/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/fx/caw.vim
+++ b/after/ftplugin/fx/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gams/caw.vim
+++ b/after/ftplugin/gams/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '*'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gams/caw.vim
+++ b/after/ftplugin/gams/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '*'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gdb/caw.vim
+++ b/after/ftplugin/gdb/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gdb/caw.vim
+++ b/after/ftplugin/gdb/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gdmo/caw.vim
+++ b/after/ftplugin/gdmo/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gdmo/caw.vim
+++ b/after/ftplugin/gdmo/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/genshi/caw.vim
+++ b/after/ftplugin/genshi/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/genshi/caw.vim
+++ b/after/ftplugin/genshi/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-conf-d/caw.vim
+++ b/after/ftplugin/gentoo-conf-d/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-conf-d/caw.vim
+++ b/after/ftplugin/gentoo-conf-d/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-env-d/caw.vim
+++ b/after/ftplugin/gentoo-env-d/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-env-d/caw.vim
+++ b/after/ftplugin/gentoo-env-d/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-init-d/caw.vim
+++ b/after/ftplugin/gentoo-init-d/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-init-d/caw.vim
+++ b/after/ftplugin/gentoo-init-d/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-make-conf/caw.vim
+++ b/after/ftplugin/gentoo-make-conf/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-make-conf/caw.vim
+++ b/after/ftplugin/gentoo-make-conf/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-package-keywords/caw.vim
+++ b/after/ftplugin/gentoo-package-keywords/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-package-keywords/caw.vim
+++ b/after/ftplugin/gentoo-package-keywords/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-package-mask/caw.vim
+++ b/after/ftplugin/gentoo-package-mask/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-package-mask/caw.vim
+++ b/after/ftplugin/gentoo-package-mask/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-package-use/caw.vim
+++ b/after/ftplugin/gentoo-package-use/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gentoo-package-use/caw.vim
+++ b/after/ftplugin/gentoo-package-use/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gitcommit/caw.vim
+++ b/after/ftplugin/gitcommit/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gitcommit/caw.vim
+++ b/after/ftplugin/gitcommit/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gitconfig/caw.vim
+++ b/after/ftplugin/gitconfig/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gitconfig/caw.vim
+++ b/after/ftplugin/gitconfig/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gitrebase/caw.vim
+++ b/after/ftplugin/gitrebase/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gitrebase/caw.vim
+++ b/after/ftplugin/gitrebase/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gnuplot/caw.vim
+++ b/after/ftplugin/gnuplot/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gnuplot/caw.vim
+++ b/after/ftplugin/gnuplot/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/go/caw.vim
+++ b/after/ftplugin/go/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/go/caw.vim
+++ b/after/ftplugin/go/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/groovy/caw.vim
+++ b/after/ftplugin/groovy/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/groovy/caw.vim
+++ b/after/ftplugin/groovy/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gtkrc/caw.vim
+++ b/after/ftplugin/gtkrc/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/gtkrc/caw.vim
+++ b/after/ftplugin/gtkrc/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/h/caw.vim
+++ b/after/ftplugin/h/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/h/caw.vim
+++ b/after/ftplugin/h/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/haml/caw.vim
+++ b/after/ftplugin/haml/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '-#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/haml/caw.vim
+++ b/after/ftplugin/haml/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '-#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/haskell/caw.vim
+++ b/after/ftplugin/haskell/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/haskell/caw.vim
+++ b/after/ftplugin/haskell/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/hb/caw.vim
+++ b/after/ftplugin/hb/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/hb/caw.vim
+++ b/after/ftplugin/hb/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/hercules/caw.vim
+++ b/after/ftplugin/hercules/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/hercules/caw.vim
+++ b/after/ftplugin/hercules/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/hog/caw.vim
+++ b/after/ftplugin/hog/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/hog/caw.vim
+++ b/after/ftplugin/hog/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/hostsaccess/caw.vim
+++ b/after/ftplugin/hostsaccess/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/hostsaccess/caw.vim
+++ b/after/ftplugin/hostsaccess/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/html/caw.vim
+++ b/after/ftplugin/html/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/html/caw.vim
+++ b/after/ftplugin/html/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/htmlcheetah/caw.vim
+++ b/after/ftplugin/htmlcheetah/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '##'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/htmlcheetah/caw.vim
+++ b/after/ftplugin/htmlcheetah/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '##'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/htmldjango/caw.vim
+++ b/after/ftplugin/htmldjango/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/htmldjango/caw.vim
+++ b/after/ftplugin/htmldjango/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/htmlos/caw.vim
+++ b/after/ftplugin/htmlos/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/htmlos/caw.vim
+++ b/after/ftplugin/htmlos/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ia64/caw.vim
+++ b/after/ftplugin/ia64/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ia64/caw.vim
+++ b/after/ftplugin/ia64/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/icon/caw.vim
+++ b/after/ftplugin/icon/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/icon/caw.vim
+++ b/after/ftplugin/icon/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/idl/caw.vim
+++ b/after/ftplugin/idl/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/idl/caw.vim
+++ b/after/ftplugin/idl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/idlang/caw.vim
+++ b/after/ftplugin/idlang/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/idlang/caw.vim
+++ b/after/ftplugin/idlang/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/inform/caw.vim
+++ b/after/ftplugin/inform/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '!'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/inform/caw.vim
+++ b/after/ftplugin/inform/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '!'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/inittab/caw.vim
+++ b/after/ftplugin/inittab/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/inittab/caw.vim
+++ b/after/ftplugin/inittab/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ishd/caw.vim
+++ b/after/ftplugin/ishd/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ishd/caw.vim
+++ b/after/ftplugin/ishd/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/iss/caw.vim
+++ b/after/ftplugin/iss/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/iss/caw.vim
+++ b/after/ftplugin/iss/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ist/caw.vim
+++ b/after/ftplugin/ist/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ist/caw.vim
+++ b/after/ftplugin/ist/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/java/caw.vim
+++ b/after/ftplugin/java/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/java/caw.vim
+++ b/after/ftplugin/java/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/javacc/caw.vim
+++ b/after/ftplugin/javacc/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/javacc/caw.vim
+++ b/after/ftplugin/javacc/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/javascript/caw.vim
+++ b/after/ftplugin/javascript/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/javascript/caw.vim
+++ b/after/ftplugin/javascript/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/jess/caw.vim
+++ b/after/ftplugin/jess/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/jess/caw.vim
+++ b/after/ftplugin/jess/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/jgraph/caw.vim
+++ b/after/ftplugin/jgraph/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/jgraph/caw.vim
+++ b/after/ftplugin/jgraph/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/jproperties/caw.vim
+++ b/after/ftplugin/jproperties/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/jproperties/caw.vim
+++ b/after/ftplugin/jproperties/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/jsp/caw.vim
+++ b/after/ftplugin/jsp/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<%--', '--%>']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/jsp/caw.vim
+++ b/after/ftplugin/jsp/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<%--', '--%>']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/julia/caw.vim
+++ b/after/ftplugin/julia/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 let b:caw_wrap_oneline_comment = ['#=', '=#']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/julia/caw.vim
+++ b/after/ftplugin/julia/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 let b:caw_wrap_oneline_comment = ['#=', '=#']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/kirikiri/caw.vim
+++ b/after/ftplugin/kirikiri/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/kirikiri/caw.vim
+++ b/after/ftplugin/kirikiri/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/kix/caw.vim
+++ b/after/ftplugin/kix/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/kix/caw.vim
+++ b/after/ftplugin/kix/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/kscript/caw.vim
+++ b/after/ftplugin/kscript/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/kscript/caw.vim
+++ b/after/ftplugin/kscript/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lace/caw.vim
+++ b/after/ftplugin/lace/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lace/caw.vim
+++ b/after/ftplugin/lace/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ldif/caw.vim
+++ b/after/ftplugin/ldif/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ldif/caw.vim
+++ b/after/ftplugin/ldif/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lilo/caw.vim
+++ b/after/ftplugin/lilo/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lilo/caw.vim
+++ b/after/ftplugin/lilo/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lilypond/caw.vim
+++ b/after/ftplugin/lilypond/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lilypond/caw.vim
+++ b/after/ftplugin/lilypond/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/liquid/caw.vim
+++ b/after/ftplugin/liquid/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['{%', '%}']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/liquid/caw.vim
+++ b/after/ftplugin/liquid/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['{%', '%}']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lisp/caw.vim
+++ b/after/ftplugin/lisp/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 let b:caw_wrap_oneline_comment = ['#|', '|#']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lisp/caw.vim
+++ b/after/ftplugin/lisp/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 let b:caw_wrap_oneline_comment = ['#|', '|#']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/llvm/caw.vim
+++ b/after/ftplugin/llvm/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/llvm/caw.vim
+++ b/after/ftplugin/llvm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lotos/caw.vim
+++ b/after/ftplugin/lotos/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lotos/caw.vim
+++ b/after/ftplugin/lotos/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lout/caw.vim
+++ b/after/ftplugin/lout/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lout/caw.vim
+++ b/after/ftplugin/lout/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lprolog/caw.vim
+++ b/after/ftplugin/lprolog/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lprolog/caw.vim
+++ b/after/ftplugin/lprolog/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lscript/caw.vim
+++ b/after/ftplugin/lscript/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ''''
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lscript/caw.vim
+++ b/after/ftplugin/lscript/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ''''
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lss/caw.vim
+++ b/after/ftplugin/lss/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lss/caw.vim
+++ b/after/ftplugin/lss/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lua/caw.vim
+++ b/after/ftplugin/lua/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 let b:caw_wrap_oneline_comment = ['--[[', ']]']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lua/caw.vim
+++ b/after/ftplugin/lua/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 let b:caw_wrap_oneline_comment = ['--[[', ']]']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lynx/caw.vim
+++ b/after/ftplugin/lynx/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lynx/caw.vim
+++ b/after/ftplugin/lynx/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lytex/caw.vim
+++ b/after/ftplugin/lytex/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/lytex/caw.vim
+++ b/after/ftplugin/lytex/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mail/caw.vim
+++ b/after/ftplugin/mail/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '>'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mail/caw.vim
+++ b/after/ftplugin/mail/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '>'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mako/caw.vim
+++ b/after/ftplugin/mako/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '##'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mako/caw.vim
+++ b/after/ftplugin/mako/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '##'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/man/caw.vim
+++ b/after/ftplugin/man/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '."'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/man/caw.vim
+++ b/after/ftplugin/man/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '."'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/map/caw.vim
+++ b/after/ftplugin/map/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/map/caw.vim
+++ b/after/ftplugin/map/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/maple/caw.vim
+++ b/after/ftplugin/maple/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/maple/caw.vim
+++ b/after/ftplugin/maple/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/markdown/caw.vim
+++ b/after/ftplugin/markdown/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/markdown/caw.vim
+++ b/after/ftplugin/markdown/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/masm/caw.vim
+++ b/after/ftplugin/masm/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/masm/caw.vim
+++ b/after/ftplugin/masm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mason/caw.vim
+++ b/after/ftplugin/mason/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<% #', '%>']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mason/caw.vim
+++ b/after/ftplugin/mason/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<% #', '%>']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/master/caw.vim
+++ b/after/ftplugin/master/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '$'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/master/caw.vim
+++ b/after/ftplugin/master/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '$'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/matlab/caw.vim
+++ b/after/ftplugin/matlab/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/matlab/caw.vim
+++ b/after/ftplugin/matlab/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mel/caw.vim
+++ b/after/ftplugin/mel/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mel/caw.vim
+++ b/after/ftplugin/mel/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mib/caw.vim
+++ b/after/ftplugin/mib/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mib/caw.vim
+++ b/after/ftplugin/mib/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mkd/caw.vim
+++ b/after/ftplugin/mkd/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '>'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mkd/caw.vim
+++ b/after/ftplugin/mkd/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '>'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mma/caw.vim
+++ b/after/ftplugin/mma/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mma/caw.vim
+++ b/after/ftplugin/mma/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/model/caw.vim
+++ b/after/ftplugin/model/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '$'
 let b:caw_wrap_oneline_comment = ['$', '$']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/model/caw.vim
+++ b/after/ftplugin/model/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '$'
 let b:caw_wrap_oneline_comment = ['$', '$']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/moduala/caw.vim
+++ b/after/ftplugin/moduala/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/moduala/caw.vim
+++ b/after/ftplugin/moduala/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/modula2/caw.vim
+++ b/after/ftplugin/modula2/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/modula2/caw.vim
+++ b/after/ftplugin/modula2/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/modula3/caw.vim
+++ b/after/ftplugin/modula3/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/modula3/caw.vim
+++ b/after/ftplugin/modula3/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/monk/caw.vim
+++ b/after/ftplugin/monk/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/monk/caw.vim
+++ b/after/ftplugin/monk/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mush/caw.vim
+++ b/after/ftplugin/mush/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/mush/caw.vim
+++ b/after/ftplugin/mush/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/named/caw.vim
+++ b/after/ftplugin/named/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/named/caw.vim
+++ b/after/ftplugin/named/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/nasm/caw.vim
+++ b/after/ftplugin/nasm/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/nasm/caw.vim
+++ b/after/ftplugin/nasm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/nastran/caw.vim
+++ b/after/ftplugin/nastran/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '$'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/nastran/caw.vim
+++ b/after/ftplugin/nastran/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '$'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/natural/caw.vim
+++ b/after/ftplugin/natural/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '/*'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/natural/caw.vim
+++ b/after/ftplugin/natural/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '/*'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ncf/caw.vim
+++ b/after/ftplugin/ncf/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ncf/caw.vim
+++ b/after/ftplugin/ncf/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/newlisp/caw.vim
+++ b/after/ftplugin/newlisp/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/newlisp/caw.vim
+++ b/after/ftplugin/newlisp/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/nginx/caw.vim
+++ b/after/ftplugin/nginx/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/nginx/caw.vim
+++ b/after/ftplugin/nginx/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/nroff/caw.vim
+++ b/after/ftplugin/nroff/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '\"'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/nroff/caw.vim
+++ b/after/ftplugin/nroff/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '\"'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/nsis/caw.vim
+++ b/after/ftplugin/nsis/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/nsis/caw.vim
+++ b/after/ftplugin/nsis/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ntp/caw.vim
+++ b/after/ftplugin/ntp/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ntp/caw.vim
+++ b/after/ftplugin/ntp/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/objc/caw.vim
+++ b/after/ftplugin/objc/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/objc/caw.vim
+++ b/after/ftplugin/objc/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/objcpp/caw.vim
+++ b/after/ftplugin/objcpp/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/objcpp/caw.vim
+++ b/after/ftplugin/objcpp/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/objj/caw.vim
+++ b/after/ftplugin/objj/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/objj/caw.vim
+++ b/after/ftplugin/objj/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ocaml/caw.vim
+++ b/after/ftplugin/ocaml/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ocaml/caw.vim
+++ b/after/ftplugin/ocaml/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/occam/caw.vim
+++ b/after/ftplugin/occam/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/occam/caw.vim
+++ b/after/ftplugin/occam/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/omlet/caw.vim
+++ b/after/ftplugin/omlet/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/omlet/caw.vim
+++ b/after/ftplugin/omlet/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/omnimark/caw.vim
+++ b/after/ftplugin/omnimark/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/omnimark/caw.vim
+++ b/after/ftplugin/omnimark/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/openroad/caw.vim
+++ b/after/ftplugin/openroad/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/openroad/caw.vim
+++ b/after/ftplugin/openroad/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/opl/caw.vim
+++ b/after/ftplugin/opl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = 'REM'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/opl/caw.vim
+++ b/after/ftplugin/opl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = 'REM'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ora/caw.vim
+++ b/after/ftplugin/ora/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ora/caw.vim
+++ b/after/ftplugin/ora/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ox/caw.vim
+++ b/after/ftplugin/ox/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ox/caw.vim
+++ b/after/ftplugin/ox/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pascal/caw.vim
+++ b/after/ftplugin/pascal/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pascal/caw.vim
+++ b/after/ftplugin/pascal/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/patran/caw.vim
+++ b/after/ftplugin/patran/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '$'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/patran/caw.vim
+++ b/after/ftplugin/patran/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '$'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pcap/caw.vim
+++ b/after/ftplugin/pcap/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pcap/caw.vim
+++ b/after/ftplugin/pcap/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pccts/caw.vim
+++ b/after/ftplugin/pccts/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pccts/caw.vim
+++ b/after/ftplugin/pccts/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pdf/caw.vim
+++ b/after/ftplugin/pdf/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pdf/caw.vim
+++ b/after/ftplugin/pdf/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/perl/caw.vim
+++ b/after/ftplugin/perl/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 let b:caw_wrap_multiline_comment = {'right': '#', 'bottom': '#', 'left': '#', 'top': '#'}
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/perl/caw.vim
+++ b/after/ftplugin/perl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 let b:caw_wrap_multiline_comment = {'right': '#', 'bottom': '#', 'left': '#', 'top': '#'}
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_multiline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pfmain/caw.vim
+++ b/after/ftplugin/pfmain/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pfmain/caw.vim
+++ b/after/ftplugin/pfmain/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/php/caw.vim
+++ b/after/ftplugin/php/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/php/caw.vim
+++ b/after/ftplugin/php/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pic/caw.vim
+++ b/after/ftplugin/pic/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pic/caw.vim
+++ b/after/ftplugin/pic/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pike/caw.vim
+++ b/after/ftplugin/pike/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pike/caw.vim
+++ b/after/ftplugin/pike/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pilrc/caw.vim
+++ b/after/ftplugin/pilrc/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pilrc/caw.vim
+++ b/after/ftplugin/pilrc/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pine/caw.vim
+++ b/after/ftplugin/pine/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pine/caw.vim
+++ b/after/ftplugin/pine/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/plm/caw.vim
+++ b/after/ftplugin/plm/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/plm/caw.vim
+++ b/after/ftplugin/plm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/plsql/caw.vim
+++ b/after/ftplugin/plsql/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/plsql/caw.vim
+++ b/after/ftplugin/plsql/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/po/caw.vim
+++ b/after/ftplugin/po/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/po/caw.vim
+++ b/after/ftplugin/po/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/postscr/caw.vim
+++ b/after/ftplugin/postscr/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/postscr/caw.vim
+++ b/after/ftplugin/postscr/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pov/caw.vim
+++ b/after/ftplugin/pov/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/pov/caw.vim
+++ b/after/ftplugin/pov/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/povini/caw.vim
+++ b/after/ftplugin/povini/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/povini/caw.vim
+++ b/after/ftplugin/povini/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ppd/caw.vim
+++ b/after/ftplugin/ppd/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ppd/caw.vim
+++ b/after/ftplugin/ppd/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ppwiz/caw.vim
+++ b/after/ftplugin/ppwiz/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ppwiz/caw.vim
+++ b/after/ftplugin/ppwiz/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/processing/caw.vim
+++ b/after/ftplugin/processing/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/processing/caw.vim
+++ b/after/ftplugin/processing/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/prolog/caw.vim
+++ b/after/ftplugin/prolog/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/prolog/caw.vim
+++ b/after/ftplugin/prolog/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ps1/caw.vim
+++ b/after/ftplugin/ps1/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ps1/caw.vim
+++ b/after/ftplugin/ps1/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/psf/caw.vim
+++ b/after/ftplugin/psf/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/psf/caw.vim
+++ b/after/ftplugin/psf/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ptcap/caw.vim
+++ b/after/ftplugin/ptcap/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ptcap/caw.vim
+++ b/after/ftplugin/ptcap/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/python/caw.vim
+++ b/after/ftplugin/python/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/python/caw.vim
+++ b/after/ftplugin/python/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/r/caw.vim
+++ b/after/ftplugin/r/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/r/caw.vim
+++ b/after/ftplugin/r/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/radiance/caw.vim
+++ b/after/ftplugin/radiance/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/radiance/caw.vim
+++ b/after/ftplugin/radiance/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ratpoison/caw.vim
+++ b/after/ftplugin/ratpoison/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ratpoison/caw.vim
+++ b/after/ftplugin/ratpoison/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/rc/caw.vim
+++ b/after/ftplugin/rc/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/rc/caw.vim
+++ b/after/ftplugin/rc/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/rebol/caw.vim
+++ b/after/ftplugin/rebol/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/rebol/caw.vim
+++ b/after/ftplugin/rebol/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/registry/caw.vim
+++ b/after/ftplugin/registry/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/registry/caw.vim
+++ b/after/ftplugin/registry/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/remind/caw.vim
+++ b/after/ftplugin/remind/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/remind/caw.vim
+++ b/after/ftplugin/remind/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/resolv/caw.vim
+++ b/after/ftplugin/resolv/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/resolv/caw.vim
+++ b/after/ftplugin/resolv/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/rgb/caw.vim
+++ b/after/ftplugin/rgb/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '!'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/rgb/caw.vim
+++ b/after/ftplugin/rgb/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '!'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/rib/caw.vim
+++ b/after/ftplugin/rib/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/rib/caw.vim
+++ b/after/ftplugin/rib/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/robots/caw.vim
+++ b/after/ftplugin/robots/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/robots/caw.vim
+++ b/after/ftplugin/robots/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ruby/caw.vim
+++ b/after/ftplugin/ruby/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 let b:caw_wrap_multiline_comment = {'right': '#', 'bottom': '#', 'left': '#', 'top': '#'}
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/ruby/caw.vim
+++ b/after/ftplugin/ruby/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 let b:caw_wrap_multiline_comment = {'right': '#', 'bottom': '#', 'left': '#', 'top': '#'}
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_multiline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sa/caw.vim
+++ b/after/ftplugin/sa/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sa/caw.vim
+++ b/after/ftplugin/sa/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/samba/caw.vim
+++ b/after/ftplugin/samba/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/samba/caw.vim
+++ b/after/ftplugin/samba/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sass/caw.vim
+++ b/after/ftplugin/sass/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sass/caw.vim
+++ b/after/ftplugin/sass/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sather/caw.vim
+++ b/after/ftplugin/sather/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sather/caw.vim
+++ b/after/ftplugin/sather/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/scala/caw.vim
+++ b/after/ftplugin/scala/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/scala/caw.vim
+++ b/after/ftplugin/scala/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/scheme/caw.vim
+++ b/after/ftplugin/scheme/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/scheme/caw.vim
+++ b/after/ftplugin/scheme/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/scilab/caw.vim
+++ b/after/ftplugin/scilab/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/scilab/caw.vim
+++ b/after/ftplugin/scilab/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/scsh/caw.vim
+++ b/after/ftplugin/scsh/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/scsh/caw.vim
+++ b/after/ftplugin/scsh/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sed/caw.vim
+++ b/after/ftplugin/sed/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sed/caw.vim
+++ b/after/ftplugin/sed/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sgmldecl/caw.vim
+++ b/after/ftplugin/sgmldecl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['--', '--']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sgmldecl/caw.vim
+++ b/after/ftplugin/sgmldecl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['--', '--']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sgmllnx/caw.vim
+++ b/after/ftplugin/sgmllnx/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sgmllnx/caw.vim
+++ b/after/ftplugin/sgmllnx/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<!--', '-->']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sh/caw.vim
+++ b/after/ftplugin/sh/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sh/caw.vim
+++ b/after/ftplugin/sh/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sicad/caw.vim
+++ b/after/ftplugin/sicad/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '*'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sicad/caw.vim
+++ b/after/ftplugin/sicad/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '*'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/simula/caw.vim
+++ b/after/ftplugin/simula/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/simula/caw.vim
+++ b/after/ftplugin/simula/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sinda/caw.vim
+++ b/after/ftplugin/sinda/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '$'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sinda/caw.vim
+++ b/after/ftplugin/sinda/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '$'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/skill/caw.vim
+++ b/after/ftplugin/skill/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/skill/caw.vim
+++ b/after/ftplugin/skill/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/slang/caw.vim
+++ b/after/ftplugin/slang/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/slang/caw.vim
+++ b/after/ftplugin/slang/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/slice/caw.vim
+++ b/after/ftplugin/slice/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/slice/caw.vim
+++ b/after/ftplugin/slice/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/slim/caw.vim
+++ b/after/ftplugin/slim/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '/'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/slim/caw.vim
+++ b/after/ftplugin/slim/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '/'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/slrnrc/caw.vim
+++ b/after/ftplugin/slrnrc/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/slrnrc/caw.vim
+++ b/after/ftplugin/slrnrc/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sm/caw.vim
+++ b/after/ftplugin/sm/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sm/caw.vim
+++ b/after/ftplugin/sm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/smarty/caw.vim
+++ b/after/ftplugin/smarty/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['{*', '*}']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/smarty/caw.vim
+++ b/after/ftplugin/smarty/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['{*', '*}']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/smil/caw.vim
+++ b/after/ftplugin/smil/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['<!', '>']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/smil/caw.vim
+++ b/after/ftplugin/smil/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['<!', '>']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/smith/caw.vim
+++ b/after/ftplugin/smith/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/smith/caw.vim
+++ b/after/ftplugin/smith/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sml/caw.vim
+++ b/after/ftplugin/sml/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sml/caw.vim
+++ b/after/ftplugin/sml/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['(*', '*)']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/snnsnet/caw.vim
+++ b/after/ftplugin/snnsnet/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/snnsnet/caw.vim
+++ b/after/ftplugin/snnsnet/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/snnspat/caw.vim
+++ b/after/ftplugin/snnspat/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/snnspat/caw.vim
+++ b/after/ftplugin/snnspat/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/snnsres/caw.vim
+++ b/after/ftplugin/snnsres/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/snnsres/caw.vim
+++ b/after/ftplugin/snnsres/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/snobol4/caw.vim
+++ b/after/ftplugin/snobol4/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '*'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/snobol4/caw.vim
+++ b/after/ftplugin/snobol4/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '*'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/spec/caw.vim
+++ b/after/ftplugin/spec/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/spec/caw.vim
+++ b/after/ftplugin/spec/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/specman/caw.vim
+++ b/after/ftplugin/specman/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/specman/caw.vim
+++ b/after/ftplugin/specman/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/spectre/caw.vim
+++ b/after/ftplugin/spectre/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/spectre/caw.vim
+++ b/after/ftplugin/spectre/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/spice/caw.vim
+++ b/after/ftplugin/spice/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '$'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/spice/caw.vim
+++ b/after/ftplugin/spice/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '$'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sql/caw.vim
+++ b/after/ftplugin/sql/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sql/caw.vim
+++ b/after/ftplugin/sql/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sqlforms/caw.vim
+++ b/after/ftplugin/sqlforms/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sqlforms/caw.vim
+++ b/after/ftplugin/sqlforms/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sqlj/caw.vim
+++ b/after/ftplugin/sqlj/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sqlj/caw.vim
+++ b/after/ftplugin/sqlj/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sqr/caw.vim
+++ b/after/ftplugin/sqr/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '!'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/sqr/caw.vim
+++ b/after/ftplugin/sqr/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '!'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/squid/caw.vim
+++ b/after/ftplugin/squid/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/squid/caw.vim
+++ b/after/ftplugin/squid/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/st/caw.vim
+++ b/after/ftplugin/st/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '"'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/st/caw.vim
+++ b/after/ftplugin/st/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '"'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/stp/caw.vim
+++ b/after/ftplugin/stp/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/stp/caw.vim
+++ b/after/ftplugin/stp/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/systemverilog/caw.vim
+++ b/after/ftplugin/systemverilog/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/systemverilog/caw.vim
+++ b/after/ftplugin/systemverilog/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tads/caw.vim
+++ b/after/ftplugin/tads/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tads/caw.vim
+++ b/after/ftplugin/tads/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tak/caw.vim
+++ b/after/ftplugin/tak/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '$'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tak/caw.vim
+++ b/after/ftplugin/tak/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '$'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tasm/caw.vim
+++ b/after/ftplugin/tasm/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tasm/caw.vim
+++ b/after/ftplugin/tasm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tcl/caw.vim
+++ b/after/ftplugin/tcl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tcl/caw.vim
+++ b/after/ftplugin/tcl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/texinfo/caw.vim
+++ b/after/ftplugin/texinfo/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '@c'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/texinfo/caw.vim
+++ b/after/ftplugin/texinfo/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '@c'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/texmf/caw.vim
+++ b/after/ftplugin/texmf/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/texmf/caw.vim
+++ b/after/ftplugin/texmf/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tf/caw.vim
+++ b/after/ftplugin/tf/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tf/caw.vim
+++ b/after/ftplugin/tf/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tidy/caw.vim
+++ b/after/ftplugin/tidy/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tidy/caw.vim
+++ b/after/ftplugin/tidy/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tli/caw.vim
+++ b/after/ftplugin/tli/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tli/caw.vim
+++ b/after/ftplugin/tli/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tmux/caw.vim
+++ b/after/ftplugin/tmux/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tmux/caw.vim
+++ b/after/ftplugin/tmux/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/trasys/caw.vim
+++ b/after/ftplugin/trasys/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '$'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/trasys/caw.vim
+++ b/after/ftplugin/trasys/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '$'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tsalt/caw.vim
+++ b/after/ftplugin/tsalt/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tsalt/caw.vim
+++ b/after/ftplugin/tsalt/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tsscl/caw.vim
+++ b/after/ftplugin/tsscl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tsscl/caw.vim
+++ b/after/ftplugin/tsscl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tssgm/caw.vim
+++ b/after/ftplugin/tssgm/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = 'comment = '''
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/tssgm/caw.vim
+++ b/after/ftplugin/tssgm/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = 'comment = '''
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/txt2tags/caw.vim
+++ b/after/ftplugin/txt2tags/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/txt2tags/caw.vim
+++ b/after/ftplugin/txt2tags/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/uc/caw.vim
+++ b/after/ftplugin/uc/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/uc/caw.vim
+++ b/after/ftplugin/uc/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/uil/caw.vim
+++ b/after/ftplugin/uil/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '!'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/uil/caw.vim
+++ b/after/ftplugin/uil/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '!'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vb/caw.vim
+++ b/after/ftplugin/vb/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ''''
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vb/caw.vim
+++ b/after/ftplugin/vb/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ''''
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/velocity/caw.vim
+++ b/after/ftplugin/velocity/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '##'
 let b:caw_wrap_oneline_comment = ['#*', '*#']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/velocity/caw.vim
+++ b/after/ftplugin/velocity/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '##'
 let b:caw_wrap_oneline_comment = ['#*', '*#']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vera/caw.vim
+++ b/after/ftplugin/vera/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vera/caw.vim
+++ b/after/ftplugin/vera/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/verilog/caw.vim
+++ b/after/ftplugin/verilog/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/verilog/caw.vim
+++ b/after/ftplugin/verilog/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/verilog_systemverilog/caw.vim
+++ b/after/ftplugin/verilog_systemverilog/caw.vim
@@ -3,20 +3,17 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/verilog_systemverilog/caw.vim
+++ b/after/ftplugin/verilog_systemverilog/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
 
@@ -11,6 +15,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vgrindefs/caw.vim
+++ b/after/ftplugin/vgrindefs/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vgrindefs/caw.vim
+++ b/after/ftplugin/vgrindefs/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vhdl/caw.vim
+++ b/after/ftplugin/vhdl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '--'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vhdl/caw.vim
+++ b/after/ftplugin/vhdl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '--'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vim/caw.vim
+++ b/after/ftplugin/vim/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '"'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vim/caw.vim
+++ b/after/ftplugin/vim/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '"'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vimperator/caw.vim
+++ b/after/ftplugin/vimperator/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '"'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vimperator/caw.vim
+++ b/after/ftplugin/vimperator/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '"'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/virata/caw.vim
+++ b/after/ftplugin/virata/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '%'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/virata/caw.vim
+++ b/after/ftplugin/virata/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '%'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vrml/caw.vim
+++ b/after/ftplugin/vrml/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vrml/caw.vim
+++ b/after/ftplugin/vrml/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vsejcl/caw.vim
+++ b/after/ftplugin/vsejcl/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '/*'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/vsejcl/caw.vim
+++ b/after/ftplugin/vsejcl/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '/*'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/webmacro/caw.vim
+++ b/after/ftplugin/webmacro/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '##'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/webmacro/caw.vim
+++ b/after/ftplugin/webmacro/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '##'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/wget/caw.vim
+++ b/after/ftplugin/wget/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/wget/caw.vim
+++ b/after/ftplugin/wget/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/winbatch/caw.vim
+++ b/after/ftplugin/winbatch/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/winbatch/caw.vim
+++ b/after/ftplugin/winbatch/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/wml/caw.vim
+++ b/after/ftplugin/wml/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/wml/caw.vim
+++ b/after/ftplugin/wml/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/wvdial/caw.vim
+++ b/after/ftplugin/wvdial/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/wvdial/caw.vim
+++ b/after/ftplugin/wvdial/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/xdefaults/caw.vim
+++ b/after/ftplugin/xdefaults/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '!'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/xdefaults/caw.vim
+++ b/after/ftplugin/xdefaults/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '!'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/xkb/caw.vim
+++ b/after/ftplugin/xkb/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '//'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/xkb/caw.vim
+++ b/after/ftplugin/xkb/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '//'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/xmath/caw.vim
+++ b/after/ftplugin/xmath/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/xmath/caw.vim
+++ b/after/ftplugin/xmath/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/xpm2/caw.vim
+++ b/after/ftplugin/xpm2/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '!'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/xpm2/caw.vim
+++ b/after/ftplugin/xpm2/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '!'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/xquery/caw.vim
+++ b/after/ftplugin/xquery/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_wrap_oneline_comment = ['(:', ':)']
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_wrap_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/xquery/caw.vim
+++ b/after/ftplugin/xquery/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_wrap_oneline_comment = ['(:', ':)']
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/z8a/caw.vim
+++ b/after/ftplugin/z8a/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = ';'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/z8a/caw.vim
+++ b/after/ftplugin/z8a/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = ';'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/zimbu/caw.vim
+++ b/after/ftplugin/zimbu/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/zimbu/caw.vim
+++ b/after/ftplugin/zimbu/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/zsh/caw.vim
+++ b/after/ftplugin/zsh/caw.vim
@@ -3,19 +3,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 let b:caw_oneline_comment = '#'
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/after/ftplugin/zsh/caw.vim
+++ b/after/ftplugin/zsh/caw.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 let b:caw_oneline_comment = '#'
 
 if exists('b:undo_ftplugin')
@@ -10,6 +14,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-let b:undo_ftplugin .= 'unlet b:caw_oneline_comment'
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - 'git -c advice.detachedHead=false clone https://github.com/thinca/vim-themis --quiet --branch v1.5.1 --single-branch --depth 1 %TEMP%\vim-themis'
   # vmock
   - 'git -c advice.detachedHead=false clone https://github.com/kannokanno/vmock --quiet --single-branch --depth 1 %TEMP%\vmock'
-  - 'vim -u NONE -i NONE -n -N -c "argdo call append(0, 'scriptencoding utf-8') | update" -c quit %TEMP%\vmock\autoload\**\*.vim'
+  - ps: & $Env:THEMIS_VIM -u NONE -i NONE -n -N -c "argdo call append(0, 'scriptencoding utf-8') | update" -c quit "%TEMP%\vmock\autoload\**\*.vim"
   # https://groups.google.com/forum/#!msg/vim_dev/3AkHqiD1NLE/vFw52yh_AAAJ
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:32'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:64'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   # themis
   - 'git -c advice.detachedHead=false clone https://github.com/thinca/vim-themis --quiet --branch v1.5.1 --single-branch --depth 1 %TEMP%\vim-themis'
   # vmock
-  - 'git -c advice.detachedHead=false clone https://github.com/tyru/vmock --quiet --branch fix/scriptencoding --depth 1 %TEMP%\vmock'
+  - 'git -c advice.detachedHead=false clone https://github.com/tyru/vmock --quiet --branch maint --depth 1 %TEMP%\vmock'
   # https://groups.google.com/forum/#!msg/vim_dev/3AkHqiD1NLE/vFw52yh_AAAJ
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:32'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:64'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
       [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $vim)
       $Env:THEMIS_VIM = $vim + (Get-ChildItem $vim).Name + '\vim.exe'
   # themis
-  - 'git -c advice.detachedHead=false clone https://github.com/thinca/vim-themis --quiet --branch v1.5 --single-branch --depth 1 %TEMP%\vim-themis'
+  - 'git -c advice.detachedHead=false clone https://github.com/thinca/vim-themis --quiet --branch v1.5.1 --single-branch --depth 1 %TEMP%\vim-themis'
   # vmock
   - 'git -c advice.detachedHead=false clone https://github.com/kannokanno/vmock --quiet --single-branch --depth 1 %TEMP%\vmock'
   # https://groups.google.com/forum/#!msg/vim_dev/3AkHqiD1NLE/vFw52yh_AAAJ

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
   - 'git -c advice.detachedHead=false clone https://github.com/thinca/vim-themis --quiet --branch v1.5.1 --single-branch --depth 1 %TEMP%\vim-themis'
   # vmock
   - 'git -c advice.detachedHead=false clone https://github.com/kannokanno/vmock --quiet --single-branch --depth 1 %TEMP%\vmock'
+  - 'vim -u NONE -i NONE -n -N -c "argdo call append(0, 'scriptencoding utf-8') | update" -c quit %TEMP%\vmock\autoload\**\*.vim'
   # https://groups.google.com/forum/#!msg/vim_dev/3AkHqiD1NLE/vFw52yh_AAAJ
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:32'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:64'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,9 +21,7 @@ install:
   # themis
   - 'git -c advice.detachedHead=false clone https://github.com/thinca/vim-themis --quiet --branch v1.5.1 --single-branch --depth 1 %TEMP%\vim-themis'
   # vmock
-  - 'git -c advice.detachedHead=false clone https://github.com/kannokanno/vmock --quiet --single-branch --depth 1 %TEMP%\vmock'
-  - ps: |
-      & $Env:THEMIS_VIM -u NONE -i NONE -n -N -c "argdo call append(0, 'scriptencoding utf-8') | update" -c quit "%TEMP%\vmock\autoload\**\*.vim"
+  - 'git -c advice.detachedHead=false clone https://github.com/tyru/vmock --quiet --branch fix/scriptencoding --depth 1 %TEMP%\vmock'
   # https://groups.google.com/forum/#!msg/vim_dev/3AkHqiD1NLE/vFw52yh_AAAJ
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:32'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:64'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,5 +29,5 @@ build: off
 test_script:
   - ps: |
       & $Env:THEMIS_VIM --version
-      & $Env:TEMP\vim-themis\bin\themis.bat -r --runtimepath %TEMP%\vmock --reporter dot
+      & $Env:TEMP\vim-themis\bin\themis.bat -r --runtimepath $Env:TEMP\vmock --reporter dot
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,8 @@ install:
   - 'git -c advice.detachedHead=false clone https://github.com/thinca/vim-themis --quiet --branch v1.5.1 --single-branch --depth 1 %TEMP%\vim-themis'
   # vmock
   - 'git -c advice.detachedHead=false clone https://github.com/kannokanno/vmock --quiet --single-branch --depth 1 %TEMP%\vmock'
-  - ps: & $Env:THEMIS_VIM -u NONE -i NONE -n -N -c "argdo call append(0, 'scriptencoding utf-8') | update" -c quit "%TEMP%\vmock\autoload\**\*.vim"
+  - ps: |
+      & $Env:THEMIS_VIM -u NONE -i NONE -n -N -c "argdo call append(0, 'scriptencoding utf-8') | update" -c quit "%TEMP%\vmock\autoload\**\*.vim"
   # https://groups.google.com/forum/#!msg/vim_dev/3AkHqiD1NLE/vFw52yh_AAAJ
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:32'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:64'

--- a/macros/after-ftplugin-template.vim
+++ b/macros/after-ftplugin-template.vim
@@ -3,6 +3,10 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+if exists("b:did_caw_ftplugin")
+    finish
+endif
+
 <ONELINE>
 <WRAP_ONELINE>
 <WRAP_MULTILINE>
@@ -12,6 +16,8 @@ if exists('b:undo_ftplugin')
 else
   let b:undo_ftplugin = ''
 endif
-<UNDO_FTPLUGIN>
+let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
+
+let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/macros/after-ftplugin-template.vim
+++ b/macros/after-ftplugin-template.vim
@@ -3,21 +3,18 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists("b:did_caw_ftplugin")
-    finish
-endif
-
 <ONELINE>
 <WRAP_ONELINE>
 <WRAP_MULTILINE>
 
-if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= ' | '
-else
-  let b:undo_ftplugin = ''
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
 endif
-let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment'
-
-let b:did_caw_ftplugin = 1
 
 let &cpo = s:save_cpo

--- a/macros/separate.vim
+++ b/macros/separate.vim
@@ -396,7 +396,6 @@ endfunction
 
 let s:root_dir = expand('<sfile>:h:h')
 
-" @vimlint(EVL102, 1, l:vars)
 function! s:run() abort
     let oneline = s:oneline()
     let wrap_oneline = s:wrap_oneline()
@@ -408,37 +407,35 @@ function! s:run() abort
         " Create /after/ftplugin/{filetype}/caw.vim
         let dir = s:root_dir . '/after/ftplugin/'.filetype
         silent! call mkdir(dir, 'p')
-        edit `=dir.'/caw.vim'`
-        %delete _
-        read macros/after-ftplugin-template.vim
-        1delete _
-        let vars = []
+        silent edit `=dir.'/caw.vim'`
+        silent %delete _
+        silent read macros/after-ftplugin-template.vim
+        silent 1delete _
 
+        " b:caw_oneline_comment
         if has_key(oneline, filetype)
             %s@<ONELINE>@\='let b:caw_oneline_comment = '.string(oneline[filetype])@
-            let vars += ['b:caw_oneline_comment']
         else
             g/<ONELINE>/d
         endif
+
+        " b:caw_wrap_oneline_comment
         if has_key(wrap_oneline, filetype)
             %s@<WRAP_ONELINE>@\='let b:caw_wrap_oneline_comment = '.string(wrap_oneline[filetype])@
-            let vars += ['b:caw_wrap_oneline_comment']
         else
             g/<WRAP_ONELINE>/d
         endif
+
+        " b:caw_wrap_multiline_comment
         if has_key(wrap_multiline, filetype)
             %s@<WRAP_MULTILINE>@\='let b:caw_wrap_multiline_comment = '.string(wrap_multiline[filetype])@
-            let vars += ['b:caw_wrap_multiline_comment']
         else
             g/<WRAP_MULTILINE>/d
         endif
 
-        %s@<UNDO_FTPLUGIN>@\='let b:undo_ftplugin .= ''unlet '.join(vars, ' ')."'"@
-
         write
     endfor
 endfunction
-" @vimlint(EVL102, 0, l:vars)
 
 call s:run()
 " quit

--- a/test/actions/box.vim
+++ b/test/actions/box.vim
@@ -13,6 +13,7 @@ let s:NORMAL_MODE_CONTEXT = {
 function! s:suite.before() abort
     " Load filetype=c comment strings.
     " setlocal filetype=c    " XXX: Why this isn't working?
+    unlet! b:did_caw_ftplugin
     runtime! after/ftplugin/c/caw.vim
 endfunction
 

--- a/test/actions/dollarpos.vim
+++ b/test/actions/dollarpos.vim
@@ -13,6 +13,7 @@ let s:NORMAL_MODE_CONTEXT = {
 function! s:suite.before() abort
     " Load filetype=c comment strings.
     " setlocal filetype=c    " XXX: Why this isn't working?
+    unlet! b:did_caw_ftplugin
     runtime! after/ftplugin/c/caw.vim
 endfunction
 

--- a/test/actions/jump.vim
+++ b/test/actions/jump.vim
@@ -13,6 +13,7 @@ let s:NORMAL_MODE_CONTEXT = {
 function! s:suite.before() abort
     " Load filetype=c comment strings.
     " setlocal filetype=c    " XXX: Why this isn't working?
+    unlet! b:did_caw_ftplugin
     runtime! after/ftplugin/c/caw.vim
 endfunction
 

--- a/test/actions/tildepos.vim
+++ b/test/actions/tildepos.vim
@@ -13,6 +13,7 @@ let s:NORMAL_MODE_CONTEXT = {
 function! s:suite.before() abort
     " Load filetype=c comment strings.
     " setlocal filetype=c    " XXX: Why this isn't working?
+    unlet! b:did_caw_ftplugin
     runtime! after/ftplugin/c/caw.vim
 endfunction
 

--- a/test/actions/wrap.vim
+++ b/test/actions/wrap.vim
@@ -13,6 +13,7 @@ let s:NORMAL_MODE_CONTEXT = {
 function! s:suite.before() abort
     " Load filetype=c comment strings.
     " setlocal filetype=c    " XXX: Why this isn't working?
+    unlet! b:did_caw_ftplugin
     runtime! after/ftplugin/c/caw.vim
 endfunction
 

--- a/test/actions/zeropos.vim
+++ b/test/actions/zeropos.vim
@@ -13,6 +13,7 @@ let s:NORMAL_MODE_CONTEXT = {
 function! s:suite.before() abort
     " Load filetype=c comment strings.
     " setlocal filetype=c    " XXX: Why this isn't working?
+    unlet! b:did_caw_ftplugin
     runtime! after/ftplugin/c/caw.vim
 endfunction
 


### PR DESCRIPTION
#46 の問題を修正しました。
報告して頂いた @machakann さんによろしければ試して頂きたいです。

* テンプレートを修正 (`macros/` 以下)
* 再度各ファイルタイプスクリプト (`after/ftplugin/{filetype}/caw.vim`) を生成

## TODO

1. [x] `b:did_caw_ftplugin` も `:unlet!` したほうがいい？
  * した方が良い (thanks @thinca)
2. [x] ~~Travis~~AppVeyor が fail する原因を究明する (まだ Vim 本体側の問題って残ってたっけ？)
  * https://ci.appveyor.com/project/tyru/caw-vim/build/58/job/6oxehpve65q6cm7y
3. [x] themis のバージョンを上げる (これで2が直るかも？)
  * v1.5.1 に上げたけど直らなかった
4. [x] @machakann さんから #46 で指摘頂いた件
  * ftplugin の冒頭のチェックを削除して `b:undo_ftplugin` の処理を冒頭の変数チェックで囲むと直る？