### PR TITLE
Wrong mapping name <Plug>(caw:tildepos:toggle)

### DIFF
--- a/autoload/caw/actions/hatpos.vim
+++ b/autoload/caw/actions/hatpos.vim
@@ -1,12 +1,12 @@
 scriptencoding utf-8
 
-function! caw#actions#tildepos#new() abort
+function! caw#actions#hatpos#new() abort
     let commentable = caw#new('actions.traits.commentable')
     let uncommentable = caw#new('actions.traits.uncommentable')
     let togglable = caw#new('actions.traits.togglable')
     let comment_detectable = caw#new('actions.traits.comment_detectable')
 
-    let obj = deepcopy(s:tildepos)
+    let obj = deepcopy(s:hatpos)
     " Implements methods.
     let obj.comment = commentable.comment
     let obj.uncomment = uncommentable.uncomment
@@ -22,17 +22,17 @@ function! caw#actions#tildepos#new() abort
 endfunction
 
 
-let s:tildepos = {'fallback_types': ['wrap']}
+let s:hatpos = {'fallback_types': ['wrap']}
 
-function! s:tildepos.comment_normal(lnum, ...) abort
+function! s:hatpos.comment_normal(lnum, ...) abort
     " NOTE: min_indent_num is byte length. not display width.
 
-    let startinsert = get(a:000, 0, caw#get_var('caw_tildepos_startinsert_at_blank_line'))
+    let startinsert = get(a:000, 0, caw#get_var('caw_hatpos_startinsert_at_blank_line'))
     let min_indent_num = get(a:000, 1, -1)
     let line = caw#getline(a:lnum)
-    let caw_tildepos_sp = line =~# '^\s*$' ?
-    \               caw#get_var('caw_tildepos_sp_blank') :
-    \               caw#get_var('caw_tildepos_sp')
+    let caw_hatpos_sp = line =~# '^\s*$' ?
+    \               caw#get_var('caw_hatpos_sp_blank') :
+    \               caw#get_var('caw_hatpos_sp')
 
     let cmt = self.comment_database.get_comment()
     call caw#assert(!empty(cmt), "`cmt` must not be empty.")
@@ -45,21 +45,21 @@ function! s:tildepos.comment_normal(lnum, ...) abort
         call caw#assert(min_indent_num <= strlen(line), min_indent_num.' is accessible to '.string(line).'.')
         let before = min_indent_num ==# 0 ? '' : line[: min_indent_num - 1]
         let after  = min_indent_num ==# 0 ? line : line[min_indent_num :]
-        call caw#setline(a:lnum, before . cmt . caw_tildepos_sp . after)
+        call caw#setline(a:lnum, before . cmt . caw_hatpos_sp . after)
     elseif line =~# '^\s*$'
-        execute 'normal! '.a:lnum.'G"_cc' . cmt . caw_tildepos_sp
+        execute 'normal! '.a:lnum.'G"_cc' . cmt . caw_hatpos_sp
         if startinsert && caw#context().mode ==# 'n'
             call caw#startinsert('A')
         endif
     else
         let indent = caw#get_inserted_indent(a:lnum)
         let line = substitute(caw#getline(a:lnum), '^[ \t]\+', '', '')
-        call caw#setline(a:lnum, indent . cmt . caw_tildepos_sp . line)
+        call caw#setline(a:lnum, indent . cmt . caw_hatpos_sp . line)
     endif
 endfunction
 
-function! s:tildepos.comment_visual() abort
-    if caw#get_var('caw_tildepos_align')
+function! s:hatpos.comment_visual() abort
+    if caw#get_var('caw_hatpos_align')
         let min_indent_num =
         \   caw#get_min_indent_num(
         \       1,
@@ -71,7 +71,7 @@ function! s:tildepos.comment_visual() abort
     \   caw#context().firstline,
     \   caw#context().lastline
     \)
-        if caw#get_var('caw_tildepos_skip_blank_line') && caw#getline(lnum) =~ '^\s*$'
+        if caw#get_var('caw_hatpos_skip_blank_line') && caw#getline(lnum) =~ '^\s*$'
             continue    " Skip blank line.
         endif
         if exists('min_indent_num')
@@ -82,14 +82,14 @@ function! s:tildepos.comment_visual() abort
     endfor
 endfunction
 
-function! s:tildepos.has_comment_normal(lnum) abort
+function! s:hatpos.has_comment_normal(lnum) abort
     let cmt = caw#new('comments.oneline').get_comment()
     if empty(cmt) | return 0 | endif
     let line_without_indent = substitute(caw#getline(a:lnum), '^[ \t]\+', '', '')
     return stridx(line_without_indent, cmt) == 0
 endfunction
 
-function! s:tildepos.uncomment_normal(lnum) abort
+function! s:hatpos.uncomment_normal(lnum) abort
     let cmt = self.comment_database.get_comment()
     call caw#assert(!empty(cmt), "`cmt` must not be empty.")
 
@@ -99,9 +99,9 @@ function! s:tildepos.uncomment_normal(lnum) abort
         if stridx(line, cmt) == 0
             " Remove comment.
             let line = line[strlen(cmt) :]
-            " 'caw_tildepos_sp'
-            if stridx(line, caw#get_var('caw_tildepos_sp')) ==# 0
-                let line = line[strlen(caw#get_var('caw_tildepos_sp')) :]
+            " 'caw_hatpos_sp'
+            if stridx(line, caw#get_var('caw_hatpos_sp')) ==# 0
+                let line = line[strlen(caw#get_var('caw_hatpos_sp')) :]
             endif
             call caw#setline(a:lnum, indent . line)
         endif

--- a/autoload/caw/actions/input.vim
+++ b/autoload/caw/actions/input.vim
@@ -50,7 +50,7 @@ function! s:ask_action() abort
     let NONE = ['', '']
 
     let actname = get({
-    \   'i': 'tildepos',
+    \   'i': 'hatpos',
     \   'I': 'zeropos',
     \   'a': 'dollarpos',
     \   'j': 'jump',

--- a/autoload/caw/actions/wrap.vim
+++ b/autoload/caw/actions/wrap.vim
@@ -22,7 +22,7 @@ function! caw#actions#wrap#new() abort
 endfunction
 
 
-let s:wrap = {'fallback_types': ['tildepos']}
+let s:wrap = {'fallback_types': ['hatpos']}
 
 function! s:wrap.comment_normal(lnum, ...) abort
     let left_col = get(a:000, 0, -1)

--- a/autoload/caw/actions/zeropos.vim
+++ b/autoload/caw/actions/zeropos.vim
@@ -1,7 +1,7 @@
 scriptencoding utf-8
 
 function! caw#actions#zeropos#new() abort
-    let obj = deepcopy(caw#new('actions.tildepos'))
+    let obj = deepcopy(caw#new('actions.hatpos'))
     let obj = extend(obj, deepcopy(s:zeropos), 'force')
     return obj
 endfunction

--- a/plugin/caw.vim
+++ b/plugin/caw.vim
@@ -98,10 +98,7 @@ call s:define_prefix('gc')
 
 
 function! s:map_generic(action, method, ...) abort
-    let has_deprecated_action = has_key(s:deprecated, a:action)
     let lhs = printf('<Plug>(caw:%s:%s)', a:action, a:method)
-    let deprecated_lhs = printf('<Plug>(caw:%s:%s)',
-    \                       get(s:deprecated, a:action, ''), a:method)
     let modes = get(a:000, 0, 'nx')
     for mode in split(modes, '\zs')
         execute
@@ -113,19 +110,19 @@ function! s:map_generic(action, method, ...) abort
         \       string(mode),
         \       string(a:action),
         \       string(a:method))
-        if has_deprecated_action
+        for deprecated_action in get(s:deprecated, a:action, [])
             execute
             \   mode . 'noremap'
             \   '<silent>'
-            \   deprecated_lhs
+            \   printf('<Plug>(caw:%s:%s)', deprecated_action, a:method)
             \   printf(
             \       ':<C-u>call caw#keymapping_stub_deprecated'
             \                       . '(%s, %s, %s, %s)<CR>',
             \       string(mode),
             \       string(a:action),
             \       string(a:method),
-            \       string(s:deprecated[a:action]))
-        endif
+            \       string(deprecated_action))
+        endfor
     endfor
 endfunction
 

--- a/plugin/caw.vim
+++ b/plugin/caw.vim
@@ -15,27 +15,32 @@ set cpo&vim
 
 " key: current action name, value: old action name
 let s:deprecated = {
-\   'tildepos': 'i',
-\   'zeropos': 'I',
-\   'dollarpos': 'a',
+\   'hatpos': ['i', 'tildepos'],
+\   'zeropos': ['I'],
+\   'dollarpos': ['a'],
 \}
 
 " Global variables {{{
 let g:caw_no_default_keymappings = get(g:, 'caw_no_default_keymappings', 0)
-" If a old variable exists, show deprecation message
+" If any of old variables exists, show deprecation message
 " and set the value to a new variable.
 function! s:def_deprecated(name, value) abort
-    let m = matchlist(a:name, '\v^caw_(tildepos|zeropos|dollarpos)')
+    let m = matchlist(a:name, '\v^caw_(hatpos|zeropos|dollarpos)')
     if !empty(m)
-        let oldvarname = substitute(
-        \   a:name, '^caw_' . m[1], 'caw_' . s:deprecated[m[1]], ''
-        \)
-        if has_key(g:, oldvarname)
-            echohl WarningMsg
-            echomsg printf('g:%s is deprecated. please use g:%s instead.', oldvarname, a:name)
-            echohl None
-            let g:[a:name] = g:[oldvarname]
-        else
+        let found = 0
+        for d in s:deprecated[m[1]]
+            let oldvarname = substitute(
+            \   a:name, '^caw_' . m[1], 'caw_' . d, ''
+            \)
+            if has_key(g:, oldvarname)
+                echohl WarningMsg
+                echomsg printf('g:%s is deprecated. please use g:%s instead.', oldvarname, a:name)
+                echohl None
+                let g:[a:name] = g:[oldvarname]
+                let found = 1
+            endif
+        endfor
+        if !found
             let g:[a:name] = get(g:, a:name, a:value)
         endif
     else
@@ -47,11 +52,11 @@ function! s:def(name, value) abort
     let g:[a:name] = get(g:, a:name, a:value)
 endfunction
 
-call s:def_deprecated('caw_tildepos_sp', ' ')
-call s:def_deprecated('caw_tildepos_sp_blank', '')
-call s:def_deprecated('caw_tildepos_startinsert_at_blank_line', 1)
-call s:def_deprecated('caw_tildepos_skip_blank_line', 0)
-call s:def_deprecated('caw_tildepos_align', 1)
+call s:def_deprecated('caw_hatpos_sp', ' ')
+call s:def_deprecated('caw_hatpos_sp_blank', '')
+call s:def_deprecated('caw_hatpos_startinsert_at_blank_line', 1)
+call s:def_deprecated('caw_hatpos_skip_blank_line', 0)
+call s:def_deprecated('caw_hatpos_align', 1)
 
 call s:def_deprecated('caw_zeropos_sp', ' ')
 call s:def_deprecated('caw_zeropos_sp_blank', '')
@@ -137,15 +142,15 @@ endfunction
 
 
 
-" tildepos {{{
-call s:map_generic('tildepos', 'comment', 'nx')
-call s:map_generic('tildepos', 'uncomment', 'nx')
-call s:map_generic('tildepos', 'toggle', 'nx')
+" hatpos {{{
+call s:map_generic('hatpos', 'comment', 'nx')
+call s:map_generic('hatpos', 'uncomment', 'nx')
+call s:map_generic('hatpos', 'toggle', 'nx')
 
 if !g:caw_no_default_keymappings
-    call s:map_user('i', 'tildepos:comment')
-    call s:map_user('ui', 'tildepos:uncomment')
-    call s:map_user('c', 'tildepos:toggle')
+    call s:map_user('i', 'hatpos:comment')
+    call s:map_user('ui', 'hatpos:uncomment')
+    call s:map_user('c', 'hatpos:toggle')
 endif
 " }}}
 

--- a/test/actions/hatpos.vim
+++ b/test/actions/hatpos.vim
@@ -1,6 +1,6 @@
 scriptencoding utf-8
 
-let s:suite = themis#suite('actions.tildepos')
+let s:suite = themis#suite('actions.hatpos')
 let s:assert = themis#helper('assert')
 
 let s:NORMAL_MODE_CONTEXT = {
@@ -18,7 +18,7 @@ function! s:suite.before() abort
 endfunction
 
 function! s:suite.before_each() abort
-    let s:tildepos = caw#new('actions.tildepos')
+    let s:hatpos = caw#new('actions.hatpos')
 endfunction
 
 function! s:suite.after_each() abort
@@ -37,7 +37,7 @@ function! s:suite.comment() abort
     call caw#__set_context__(deepcopy(s:NORMAL_MODE_CONTEXT))
 
     call s:assert.equals(b:caw_oneline_comment, '//')
-    call s:tildepos.comment()
+    call s:hatpos.comment()
 endfunction
 
 function! s:suite.comment_indent() abort
@@ -49,7 +49,7 @@ function! s:suite.comment_indent() abort
     call caw#__set_context__(deepcopy(s:NORMAL_MODE_CONTEXT))
 
     call s:assert.equals(b:caw_oneline_comment, '//')
-    call s:tildepos.comment()
+    call s:hatpos.comment()
 endfunction
 
 function! s:suite.uncomment() abort
@@ -61,7 +61,7 @@ function! s:suite.uncomment() abort
     call caw#__set_context__(deepcopy(s:NORMAL_MODE_CONTEXT))
 
     call s:assert.equals(b:caw_oneline_comment, '//')
-    call s:tildepos.uncomment()
+    call s:hatpos.uncomment()
 endfunction
 
 function! s:suite.uncomment_indent() abort
@@ -73,7 +73,7 @@ function! s:suite.uncomment_indent() abort
     call caw#__set_context__(deepcopy(s:NORMAL_MODE_CONTEXT))
 
     call s:assert.equals(b:caw_oneline_comment, '//')
-    call s:tildepos.uncomment()
+    call s:hatpos.uncomment()
 endfunction
 
 function! s:suite.uncomment_no_spaces() abort
@@ -85,5 +85,5 @@ function! s:suite.uncomment_no_spaces() abort
     call caw#__set_context__(deepcopy(s:NORMAL_MODE_CONTEXT))
 
     call s:assert.equals(b:caw_oneline_comment, '//')
-    call s:tildepos.uncomment()
+    call s:hatpos.uncomment()
 endfunction


### PR DESCRIPTION
## Problem

From `help caw-faq-3`:

> tildepos
> &nbsp;&nbsp;&nbsp;&nbsp;The keymappings do actions for the position where ^ command moves to.

tilde = `~`
hat = `^`

`<Plug>(caw:tildepos:toggle)` should be `<Plug>(caw:hatpos:toggle)`.

## Tasks

- Rename tildepos to hatpos
  - [x] Variables
  - [x] Mappings
- Show deprecation messages
  - [x] Variables
  - [x] Mappings
- [x] Write help
  - Will be done in #42 

## Reference

https://github.com/tyru/caw.vim/pull/42/commits/c4bbf7d4754446bdbcf9829a928f17bb45a1bdb7#r57526000