### PR TITLE
[New] Add g:caw_operator_keymappings

### DIFF
--- a/doc/caw.txt
+++ b/doc/caw.txt
@@ -25,11 +25,12 @@ Features						|caw-features|
 Supported filetypes				|caw-supported-filetypes|
 Interface						|caw-interface|
   Keymappings					|caw-keymappings|
+    Default mappings			|caw-keymappings-default|
     Prefix mapping				|caw-keymappings-prefix|
     Operator mappings			|caw-keymappings-operator|
-      Hatpos operator				|caw-hatpos-operator|
+      Hatpos operator			|caw-hatpos-operator|
       Zeropos operator			|caw-zeropos-operator|
-      Dollarpos operator			|caw-dollarpos-operator|
+      Dollarpos operator		|caw-dollarpos-operator|
       Wrap operator				|caw-wrap-operator|
       Box operator				|caw-box-operator|
     Non-operator mappings		|caw-keymappings-non-operator|
@@ -144,13 +145,47 @@ KEYMAPPINGS								*caw-keymappings* {{{
 See |caw-introduction| for how below keymappings work.
 
 
+Default mapping				*caw-keymappings-default* {{{
+---------------
+
+If |g:caw_operator_keymappings| is 0 (default):
+
+lhs		rhs ~
+gc		|<Plug>(caw:prefix)|
+gcc		|<Plug>(caw:hatpos:toggle)|
+gci		|<Plug>(caw:hatpos:comment)|
+gcui	|<Plug>(caw:hatpos:uncomment)|
+gcI		|<Plug>(caw:zeropos:comment)|
+gcuI	|<Plug>(caw:zeropos:uncomment)|
+gca		|<Plug>(caw:dollarpos:comment)|
+gcua	|<Plug>(caw:dollarpos:uncomment)|
+gcw		|<Plug>(caw:wrap:comment)|
+gcuw	|<Plug>(caw:wrap:uncomment)|
+gcb		|<Plug>(caw:box:comment)|
+gco		|<Plug>(caw:jump:comment-next)|
+gcO		|<Plug>(caw:jump:comment-prev)|
+
+If |g:caw_operator_keymappings| is non-zero:
+
+lhs		rhs ~
+gc		|<Plug>(caw:prefix)|
+gcc		|<Plug>(operator-caw-hatpos-toggle)|
+gci		|<Plug>(operator-caw-hatpos-comment)|
+gcui	|<Plug>(operator-caw-hatpos-uncomment)|
+gcI		|<Plug>(operator-caw-zeropos-comment)|
+gcuI	|<Plug>(operator-caw-zeropos-uncomment)|
+gca		|<Plug>(operator-caw-dollarpos-comment)|
+gcua	|<Plug>(operator-caw-dollarpos-uncomment)|
+gcw		|<Plug>(operator-caw-wrap-comment)|
+gcuw	|<Plug>(operator-caw-wrap-uncomment)|
+gcb		|<Plug>(operator-caw-box-comment)|
+
+}}}
+
 Prefix mapping					*caw-keymappings-prefix* {{{
 --------------
 
 (nx) <Plug>(caw:prefix)					*<Plug>(caw:prefix)*
-
-Default mapping		rhs ~
-gc					<Plug>(caw:prefix)
 
 NOTE: See |caw-faq-1| for how to change prefix keymapping.
 
@@ -236,11 +271,6 @@ Hatpos action							*caw-hatpos-action* {{{
 	* *<Plug>(caw:i:toggle)*
 	See |caw-faq-3| why I renamed the keymapping.
 
-Default mapping		rhs ~
-gci					<Plug>(caw:hatpos:comment)
-gcui				<Plug>(caw:hatpos:uncomment)
-gcc					<Plug>(caw:hatpos:toggle)
-
 }}}
 
 Zeropos action							*caw-zeropos-action* {{{
@@ -257,10 +287,6 @@ Zeropos action							*caw-zeropos-action* {{{
 	* *<Plug>(caw:I:uncomment)*
 	* *<Plug>(caw:I:toggle)*
 	See |caw-faq-3| why I renamed the keymapping.
-
-Default mapping		rhs ~
-gcI					<Plug>(caw:zeropos:comment)
-gcuI				<Plug>(caw:zeropos:uncomment)
 
 }}}
 
@@ -279,10 +305,6 @@ Dollarpos action						*caw-dollarpos-action* {{{
 	* *<Plug>(caw:a:toggle)*
 	See |caw-faq-3| why I renamed the keymapping.
 
-Default mapping		rhs ~
-gca					<Plug>(caw:dollarpos:comment)
-gcua				<Plug>(caw:dollarpos:uncomment)
-
 }}}
 
 Wrap action								*caw-wrap-action* {{{
@@ -294,10 +316,6 @@ Wrap action								*caw-wrap-action* {{{
 
 	TODO
 
-Default mapping		rhs ~
-gcw					<Plug>(caw:wrap:comment)
-gcuw				<Plug>(caw:wrap:uncomment)
-
 }}}
 
 Box action								*caw-box-action* {{{
@@ -306,9 +324,6 @@ Box action								*caw-box-action* {{{
 (nx) *<Plug>(caw:box:comment)*
 
 	TODO
-
-Default mapping		rhs ~
-gcb					<Plug>(caw:box:comment)
 
 }}}
 
@@ -319,10 +334,6 @@ Jump action								*caw-jump-action* {{{
 (n) *<Plug>(caw:jump:comment-prev)*
 
 	TODO
-
-Default mapping		rhs ~
-gco					<Plug>(caw:jump:comment-next)
-gcO					<Plug>(caw:jump:comment-prev)
 
 }}}
 
@@ -538,6 +549,11 @@ g:caw_no_default_keymappings			*g:caw_no_default_keymappings*
 	If this variable is true,
 	caw does not map default keymappings.
 	See |caw-keymappings| for default keymappings.
+
+g:caw_operator_keymappings				*g:caw_operator_keymappings*
+									(Default: 0)
+	If this variable is true,
+	caw's default keymappings become operator keymappings.
 
 g:caw_find_another_action				*g:caw_find_another_action*
 									(Default: 1)

--- a/doc/caw.txt
+++ b/doc/caw.txt
@@ -409,7 +409,7 @@ g:caw_hatpos_sp_blank
 						*g:caw_i_startinsert_at_blank_line*
 g:caw_hatpos_startinsert_at_blank_line
 									(Default: 1)
-	If this variable is true,
+	If this variable is non-zero,
 	if current line is blank line,
 	enter |Insert-mode| after <Plug>(caw:hatpos:comment).
 
@@ -429,7 +429,7 @@ g:caw_hatpos_skip_blank_line
 						*g:caw_hatpos_align* *g:caw_i_align*
 g:caw_hatpos_align
 									(Default: 1)
-	If this variable is true,
+	If this variable is non-zero,
 	Align all <Plug>(caw:hatpos:comment) comments' cols.
 
 	TODO: example
@@ -446,7 +446,7 @@ Zeropos							*caw-variables-zeropos* {{{
 						*g:caw_I_startinsert_at_blank_line*
 g:caw_zeropos_startinsert_at_blank_line
 									(Default: 1)
-	If this variable is true,
+	If this variable is non-zero,
 	if current line is blank line,
 	enter |Insert-mode| after <Plug>(caw:zeropos:comment).
 
@@ -494,7 +494,7 @@ g:caw_dollarpos_sp_right
 						*g:caw_dollarpos_startinsert* *g:caw_a_startinsert*
 g:caw_dollarpos_startinsert
 									(Default: 1)
-	If this variable is true,
+	If this variable is non-zero,
 	enter |Insert-mode| after <Plug>(caw:dollarpos:comment).
 
 	NOTE: An old variable name was |g:caw_a_startinsert|.
@@ -546,13 +546,13 @@ Others							*caw-variables-others* {{{
 
 g:caw_no_default_keymappings			*g:caw_no_default_keymappings*
 									(Default: 0)
-	If this variable is true,
+	If this variable is non-zero,
 	caw does not map default keymappings.
 	See |caw-keymappings| for default keymappings.
 
 g:caw_operator_keymappings				*g:caw_operator_keymappings*
 									(Default: 0)
-	If this variable is true,
+	If this variable is non-zero,
 	caw's default keymappings become operator keymappings.
 
 g:caw_find_another_action				*g:caw_find_another_action*

--- a/plugin/caw.vim
+++ b/plugin/caw.vim
@@ -23,7 +23,10 @@ let s:plug.deprecated = {
 \}
 
 " Global variables {{{
+
 let g:caw_no_default_keymappings = get(g:, 'caw_no_default_keymappings', 0)
+let g:caw_operator_keymappings = get(g:, 'caw_operator_keymappings', 0)
+
 " If any of old variables exists, show deprecation message
 " and set the value to a new variable.
 function! s:def_deprecated(name, value) abort
@@ -142,9 +145,15 @@ function! s:plug.map_plug(action, method, modes) abort
     endfor
 endfunction
 
-function! s:plug.map_user(lhs, rhs) abort
+function! s:plug.map_user(lhs, action, method) abort
+    if g:caw_operator_keymappings && a:action ==# 'jump'
+        " jump action does not support operator
+        return
+    endif
     let lhs = '<Plug>(caw:prefix)' . a:lhs
-    let rhs = printf('<Plug>(caw:%s)', a:rhs)
+    let rhs = g:caw_operator_keymappings ?
+    \           printf('<Plug>(operator-caw-%s-%s)', a:action, a:method) :
+    \           printf('<Plug>(caw:%s:%s)', a:action, a:method)
     for mode in ['n', 'x']
         if !hasmapto(rhs, mode)
             silent! execute
@@ -161,9 +170,9 @@ call s:plug.map('hatpos', 'uncomment', 'nx')
 call s:plug.map('hatpos', 'toggle', 'nx')
 
 if !g:caw_no_default_keymappings
-    call s:plug.map_user('i', 'hatpos:comment')
-    call s:plug.map_user('ui', 'hatpos:uncomment')
-    call s:plug.map_user('c', 'hatpos:toggle')
+    call s:plug.map_user('i', 'hatpos', 'comment')
+    call s:plug.map_user('ui', 'hatpos', 'uncomment')
+    call s:plug.map_user('c', 'hatpos', 'toggle')
 endif
 " }}}
 
@@ -173,8 +182,8 @@ call s:plug.map('zeropos', 'uncomment', 'nx')
 call s:plug.map('zeropos', 'toggle', 'nx')
 
 if !g:caw_no_default_keymappings
-    call s:plug.map_user('I', 'zeropos:comment')
-    call s:plug.map_user('uI', 'zeropos:uncomment')
+    call s:plug.map_user('I', 'zeropos', 'comment')
+    call s:plug.map_user('uI', 'zeropos', 'uncomment')
 endif
 " }}}
 
@@ -184,8 +193,8 @@ call s:plug.map('dollarpos', 'uncomment')
 call s:plug.map('dollarpos', 'toggle')
 
 if !g:caw_no_default_keymappings
-    call s:plug.map_user('a', 'dollarpos:comment')
-    call s:plug.map_user('ua', 'dollarpos:uncomment')
+    call s:plug.map_user('a', 'dollarpos', 'comment')
+    call s:plug.map_user('ua', 'dollarpos', 'uncomment')
 endif
 " }}}
 
@@ -195,8 +204,8 @@ call s:plug.map('wrap', 'uncomment')
 call s:plug.map('wrap', 'toggle')
 
 if !g:caw_no_default_keymappings
-    call s:plug.map_user('w', 'wrap:comment')
-    call s:plug.map_user('uw', 'wrap:uncomment')
+    call s:plug.map_user('w', 'wrap', 'comment')
+    call s:plug.map_user('uw', 'wrap', 'uncomment')
 endif
 " }}}
 
@@ -204,7 +213,7 @@ endif
 call s:plug.map('box', 'comment')
 
 if !g:caw_no_default_keymappings
-    call s:plug.map_user('b', 'box:comment')
+    call s:plug.map_user('b', 'box', 'comment')
 endif
 " }}}
 
@@ -213,8 +222,8 @@ call s:plug.map('jump', 'comment-next', 'n')
 call s:plug.map('jump', 'comment-prev', 'n')
 
 if !g:caw_no_default_keymappings
-    call s:plug.map_user('o', 'jump:comment-next')
-    call s:plug.map_user('O', 'jump:comment-prev')
+    call s:plug.map_user('o', 'jump', 'comment-next')
+    call s:plug.map_user('O', 'jump', 'comment-prev')
 endif
 " }}}
 


### PR DESCRIPTION
If variable `g:caw_operator_keymappings` is non-zero, all default keymappings become operator.