### PR TITLE
Disable operator keymappings if kana/vim-operator-user is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * Supports operator mappings (`|caw-keymappings-operator|`).
   * If `|g:caw_operator_keymappings|` is non-zero, all default keymappings map
     to operator mappings.
+  * If you need [kana/vim-operator-user](https://github.com/kana/vim-operator-user) to use operator mappings.
 * Supports also non-operator mappings (`|caw-keymappings-non-operator|`).
 * Dot-repeatable if you installed [kana/vim-repeat](https://github.com/kana/vim-repeat)
 * The comment behavior only depends on 'filetype' by default.

--- a/doc/caw.txt
+++ b/doc/caw.txt
@@ -116,6 +116,8 @@ FEATURES						*caw-features* {{{
 * Supports operator mappings (|caw-keymappings-operator|).
   * If |g:caw_operator_keymappings| is non-zero, all default keymappings map
     to operator mappings.
+  * If you need operator-user.vim to use operator mappings.
+    https://github.com/kana/vim-operator-user
 * Supports also non-operator mappings (|caw-keymappings-non-operator|).
 * Dot-repeatable if you installed repeat.vim
   https://github.com/kana/vim-repeat
@@ -150,7 +152,7 @@ See |caw-introduction| for how below keymappings work.
 Default mapping				*caw-keymappings-default* {{{
 ---------------
 
-If |g:caw_operator_keymappings| is 0 (default):
+If |g:caw_operator_keymappings| is zero (default):
 
 lhs		rhs ~
 gc		|<Plug>(caw:prefix)|
@@ -556,6 +558,10 @@ g:caw_operator_keymappings				*g:caw_operator_keymappings*
 									(Default: 0)
 	If this variable is non-zero,
 	caw's default keymappings become operator keymappings.
+
+	NOTE: If you haven't installed kana/vim-operator-user,
+	this variable is forcibly set to zero.
+	https://github.com/kana/vim-operator-user
 
 g:caw_find_another_action				*g:caw_find_another_action*
 									(Default: 1)

--- a/plugin/caw.vim
+++ b/plugin/caw.vim
@@ -26,6 +26,12 @@ let s:plug.deprecated = {
 
 let g:caw_no_default_keymappings = get(g:, 'caw_no_default_keymappings', 0)
 let g:caw_operator_keymappings = get(g:, 'caw_operator_keymappings', 0)
+if globpath(&rtp, 'autoload/operator/user.vim') !=# ''
+    let s:operator_user_installed = 1
+else
+    let s:operator_user_installed = 0
+    let g:caw_operator_keymappings = 0
+endif
 
 " If any of old variables exists, show deprecation message
 " and set the value to a new variable.
@@ -100,8 +106,6 @@ function! s:plug.define_prefix(lhs) abort
 endfunction
 call s:plug.define_prefix('gc')
 
-let s:operator_user_installed =
-\   (globpath(&rtp, 'autoload/operator/user.vim') !=# '')
 function! s:plug.map(action, method, ...) abort
     let modes = get(a:000, 0, 'nx')
     call s:plug.map_plug(a:action, a:method, modes)


### PR DESCRIPTION
From help:

> NOTE: If you haven't installed kana/vim-operator-user,
> this variable is forcibly set to zero.
> https://github.com/kana/vim-operator-user