### PR TITLE
Support 'tags' filetype

### DIFF
--- a/after/ftplugin/tags/caw.vim
+++ b/after/ftplugin/tags/caw.vim
@@ -1,0 +1,18 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+let s:save_cpo = &cpo
+set cpo&vim
+
+let b:caw_oneline_comment = ';'
+
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
+endif
+
+let &cpo = s:save_cpo

--- a/autoload/caw/actions/hatpos.vim
+++ b/autoload/caw/actions/hatpos.vim
@@ -67,11 +67,12 @@ function! s:hatpos.comment_visual() abort
         \       caw#context().lastline)
     endif
 
+    let skip_blank_line = caw#get_var('caw_hatpos_skip_blank_line')
     for lnum in range(
     \   caw#context().firstline,
     \   caw#context().lastline
     \)
-        if caw#get_var('caw_hatpos_skip_blank_line') && caw#getline(lnum) =~ '^\s*$'
+        if skip_blank_line && caw#getline(lnum) =~ '^\s*$'
             continue    " Skip blank line.
         endif
         if exists('min_indent_num')

--- a/autoload/caw/actions/traits/togglable.vim
+++ b/autoload/caw/actions/traits/togglable.vim
@@ -16,25 +16,20 @@ let s:togglable = {}
 
 
 function! s:togglable.toggle() abort
-    let all_comment = self.has_all_comment()
-    let mixed = !all_comment && self.has_comment()
     if caw#context().mode ==# 'n'
-        if all_comment
-            " The line is commented out.
+        if self.has_all_comment()
+            " The line has a comment string.
             call self.uncomment()
         else
-            " The line is not commented out.
+            " The line doesn't have a comment string.
             call self.comment()
         endif
     else
-        if mixed
-            " Some lines are commented out.
-            call self.comment()
-        elseif all_comment
-            " All lines are commented out.
+        if self.has_all_comment()
+            " All lines have comment strings.
             call self.uncomment()
         else
-            " All lines are not commented out.
+            " Some lines have comment strings, or no lines have comment strings.
             call self.comment()
         endif
     endif

--- a/autoload/caw/actions/wrap.vim
+++ b/autoload/caw/actions/wrap.vim
@@ -79,11 +79,12 @@ function! s:wrap.comment_visual() abort
         \       caw#context().lastline)
     endif
 
+    let skip_blank_line = caw#get_var('caw_wrap_skip_blank_line')
     for lnum in range(
     \   caw#context().firstline,
     \   caw#context().lastline
     \)
-        if caw#get_var('caw_wrap_skip_blank_line') && caw#getline(lnum) =~ '^\s*$'
+        if skip_blank_line && caw#getline(lnum) =~ '^\s*$'
             continue    " Skip blank line.
         endif
         if exists('left_col') && exists('right_col')


### PR DESCRIPTION
Merge these changes after #58.
**I** confirmed these changes don't introduce noticeable bugs
but caw.vim is currently in freeze phase (#58).

# Changes

* `tags` filetype plugin file was ignored by .gitignore (8bb95b61fd0f207b4f2b08b656830cd4bd4d95ed3)