### PR TITLE
swig: add swig filetype

### DIFF
--- a/after/ftplugin/swig/caw.vim
+++ b/after/ftplugin/swig/caw.vim
@@ -1,0 +1,20 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+let s:save_cpo = &cpo
+set cpo&vim
+
+let b:caw_oneline_comment = '//'
+let b:caw_wrap_oneline_comment = ['/*', '*/']
+let b:caw_wrap_multiline_comment = {'right': '*/', 'bottom': '*', 'left': '/*', 'top': '*'}
+
+if !exists("b:did_caw_ftplugin")
+    if exists('b:undo_ftplugin')
+        let b:undo_ftplugin .= ' | '
+    else
+        let b:undo_ftplugin = ''
+    endif
+    let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+    let b:did_caw_ftplugin = 1
+endif
+
+let &cpo = s:save_cpo


### PR DESCRIPTION
Support swig file format.
The details are below.
- Swig file format(syntax) similar C++. just copied `cpp` directory.
- Ref1: Swig official documents(latest)
  - http://www.swig.org/Doc2.0/SWIG.html
- Ref2: vim-script hosted 'SWIG-syntax' plugin source(but very old)
  - https://github.com/vim-scripts/SWIG-syntax/blob/master/syntax/swig.vim

Note that I do not totally understand the caw.vim implements..
I was copied `cpp` directory to `swig`. It works, but that's probably redundant.
Is that appropriate?

Anyway, Thanks good plugin!!
