### PR TITLE
Detects context_filetype.vim via globpath

### DIFF
--- a/autoload/caw.vim
+++ b/autoload/caw.vim
@@ -8,6 +8,7 @@ set cpo&vim
 
 
 let s:installed_repeat_vim = (globpath(&rtp, 'autoload/repeat.vim') !=# '')
+let s:installed_context_filetype = (globpath(&rtp, 'autoload/context_filetype.vim') !=# '')
 let s:op_args = ''
 let s:op_doing = 0
 
@@ -33,7 +34,7 @@ function! caw#keymapping_stub(mode, action, method) abort
 
     " Context filetype support.
     " https://github.com/Shougo/context_filetype.vim
-    if exists('*context_filetype#get_filetype')
+    if s:installed_context_filetype
         let conft = context_filetype#get_filetype()
         if conft !=# &l:filetype
             let old_filetype = &l:filetype


### PR DESCRIPTION
This fixes support for single-file vue components. I found that due to autoloading, `exists('*context_filetype#get_filetype')` would not return true until that function was called for the first time. As a workaround, I replaced this call with the `globpath` detection technique being used for repeat.vim.