### PR TITLE
Ignore comment inside string literal

### DIFF
--- a/autoload/caw.vim
+++ b/autoload/caw.vim
@@ -247,6 +247,14 @@ function! caw#trim_whitespaces(str) abort
     return str
 endfunction
 
+function! caw#trim_left(str) abort
+    return substitute(a:str, '^\s\+', '', '')
+endfunction
+
+function! caw#trim_right(str) abort
+    return substitute(a:str, '\s\+$', '', '')
+endfunction
+
 function! caw#get_min_indent_num(skip_blank_line, from_lnum, to_lnum) abort
     let min_indent_num = 1/0
     for lnum in range(a:from_lnum, a:to_lnum)

--- a/autoload/caw/actions/dollarpos.vim
+++ b/autoload/caw/actions/dollarpos.vim
@@ -16,6 +16,7 @@ function! caw#actions#dollarpos#new() abort
     let obj.has_comment_visual = comment_detectable.has_comment_visual
     let obj.has_all_comment = comment_detectable.has_all_comment
     let obj.search_synstack = comment_detectable.search_synstack
+    let obj.has_syntax = comment_detectable.has_syntax
     let obj.toggle = togglable.toggle
     " Import comment database.
     let obj.comment_database = caw#new('comments.oneline')

--- a/autoload/caw/actions/traits/comment_detectable.vim
+++ b/autoload/caw/actions/traits/comment_detectable.vim
@@ -11,8 +11,10 @@ let s:comment_detectable = {}
 " Derived object must implement those.
 "
 " s:comment_detectable.has_comment(),
-" s:comment_detectable.has_comment_visual() require:
-" - Derived.has_comment_normal()
+" s:comment_detectable.has_comment_visual(),
+" s:comment_detectable.has_comment_normal() require:
+" - Derived.comment_database.get_comments()
+" - Derived.get_commented_range()
 
 function! s:comment_detectable.has_comment() abort
     let context = caw#context()
@@ -21,6 +23,28 @@ function! s:comment_detectable.has_comment() abort
     else
         return self.has_comment_visual()
     endif
+endfunction
+
+function! s:comment_detectable.has_comment_normal(lnum) abort
+    let comments = self.comment_database.get_comments()
+    return !empty(self.get_commented_range(a:lnum, comments))
+endfunction
+
+function! s:comment_detectable.get_commented_col(lnum, needle) abort
+    let line = caw#getline(a:lnum)
+    let idx = -1
+    let start = 0
+    while 1
+        let idx = stridx(line, a:needle, start)
+        if idx ==# -1
+            break
+        endif
+        if self.has_syntax('^Comment$', a:lnum, idx + 1)
+            break
+        endif
+        let start = idx + 1
+    endwhile
+    return idx + 1
 endfunction
 
 function! s:comment_detectable.has_comment_visual() abort

--- a/autoload/caw/actions/traits/comment_detectable.vim
+++ b/autoload/caw/actions/traits/comment_detectable.vim
@@ -49,7 +49,16 @@ function! s:comment_detectable.has_all_comment() abort
     return 1
 endfunction
 
-function! s:comment_detectable.search_synstack(lnum, cmt, pattern) abort
+function! s:comment_detectable.has_syntax(synpat, lnum, col) abort
+    for id in caw#synstack(a:lnum, a:col)
+        if caw#synIDattr(synIDtrans(id), 'name') =~# a:synpat
+            return 1
+        endif
+    endfor
+    return 0
+endfunction
+
+function! s:comment_detectable.search_synstack(lnum, cmt, synpat) abort
     let line = caw#getline(a:lnum)
     let cols = []
     let idx  = -1
@@ -66,11 +75,9 @@ function! s:comment_detectable.search_synstack(lnum, cmt, pattern) abort
     endif
 
     for col in cols
-        for id in caw#synstack(a:lnum, col)
-            if caw#synIDattr(synIDtrans(id), 'name') =~# a:pattern
-                return col
-            endif
-        endfor
+        if self.has_syntax(a:synpat, a:lnum, col)
+            return col
+        endif
     endfor
     return -1
 endfunction

--- a/autoload/caw/actions/wrap.vim
+++ b/autoload/caw/actions/wrap.vim
@@ -12,6 +12,8 @@ function! caw#actions#wrap#new() abort
     let obj.uncomment = uncommentable.uncomment
     let obj.uncomment_visual = uncommentable.uncomment_visual
     let obj.has_comment = comment_detectable.has_comment
+    let obj.has_comment_normal = comment_detectable.has_comment_normal
+    let obj.get_commented_col = comment_detectable.get_commented_col
     let obj.has_comment_visual = comment_detectable.has_comment_visual
     let obj.has_all_comment = comment_detectable.has_all_comment
     let obj.search_synstack = comment_detectable.search_synstack
@@ -136,11 +138,6 @@ function! s:wrap.comment_visual_characterwise() abort
     call s:operate_on_word('<SID>comment_visual_characterwise_comment_out')
 endfunction
 
-function! s:wrap.has_comment_normal(lnum) abort
-    let comments = self.comment_database.get_comments()
-    return !empty(self.get_commented_range(a:lnum, comments))
-endfunction
-
 function! s:wrap.get_commented_range(lnum, comments) abort
     for [left, right] in a:comments
         let lcol = self.get_commented_col(a:lnum, left)
@@ -156,23 +153,6 @@ function! s:wrap.get_commented_range(lnum, comments) abort
         endif
     endfor
     return {}
-endfunction
-
-function! s:wrap.get_commented_col(lnum, needle) abort
-    let line = caw#getline(a:lnum)
-    let idx = -1
-    let start = 0
-    while 1
-        let idx = stridx(line, a:needle, start)
-        if idx ==# -1
-            break
-        endif
-        if self.has_syntax('^Comment$', a:lnum, idx + 1)
-            break
-        endif
-        let start = idx + 1
-    endwhile
-    return idx + 1
 endfunction
 
 function! s:wrap.uncomment_normal(lnum) abort


### PR DESCRIPTION
Fix #121

`dollarpos` already cares `Comment` syntax group, just refactored it.