### PR TITLE
fix: b:undo_ftplugin contain unlet(not bang) is error happen

### DIFF
--- a/autoload/caw.vim
+++ b/autoload/caw.vim
@@ -333,7 +333,7 @@ endfunction
 
 function! caw#load_ftplugin(ft) abort
   if exists('b:undo_ftplugin')
-    execute b:undo_ftplugin
+    silent! execute b:undo_ftplugin
   endif
   unlet! b:did_caw_ftplugin
   execute 'runtime! after/ftplugin/' . a:ft . '/caw.vim'


### PR DESCRIPTION
close #128

title problem solve:need silent! at execute b:undo_ftplugin.

And another PR https://github.com/kana/vim-textobj-function/pull/20 : This PR is direct fix in current problem plugin.
This PR prevents unlet no bang in unknown plugins.