### PR TITLE
[Fix] don't search possible comments

### DIFF
--- a/after/ftplugin/javascript/caw.vim
+++ b/after/ftplugin/javascript/caw.vim
@@ -3,6 +3,7 @@ scriptencoding utf-8
 
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
+let b:caw_search_possible_comments = 1
 
 if !exists('b:did_caw_ftplugin')
   if exists('b:undo_ftplugin')

--- a/after/ftplugin/typescript/caw.vim
+++ b/after/ftplugin/typescript/caw.vim
@@ -3,6 +3,7 @@ scriptencoding utf-8
 
 let b:caw_oneline_comment = '//'
 let b:caw_wrap_oneline_comment = ['/*', '*/']
+let b:caw_search_possible_comments = 1
 
 if !exists('b:did_caw_ftplugin')
   if exists('b:undo_ftplugin')

--- a/autoload/caw/comments/base.vim
+++ b/autoload/caw/comments/base.vim
@@ -8,7 +8,11 @@ endfunction
 let s:base = {}
 
 function! s:base._get_possible_comments(context, varname, by_length) abort
-  let related = self._get_related_ft_comments(a:context, a:varname)
+  if caw#get_var('caw_search_possible_comments', 0)
+    let related = self._get_related_ft_comments(a:context, a:varname)
+  else
+    let related = []
+  endif
   let comments = self.get_comments()
   return caw#uniq(sort(related + comments, a:by_length))
 endfunction

--- a/macros/generate-ftplugins.vim
+++ b/macros/generate-ftplugins.vim
@@ -431,6 +431,12 @@ function! s:additional_vars() abort
   \   'let b:caw_hatpos_ignore_syngroup = 1',
   \   'let b:caw_zeropos_ignore_syngroup = 1',
   \ ], "\n"),
+  \ 'javascript': join([
+  \   'let b:caw_search_possible_comments = 1',
+  \ ], "\n"),
+  \ 'typescript': join([
+  \   'let b:caw_search_possible_comments = 1',
+  \ ], "\n"),
   \}
 endfunction
 

--- a/test/actions/dollarpos.vim
+++ b/test/actions/dollarpos.vim
@@ -180,3 +180,36 @@ function! s:suite.uncomment_no_spaces_blank() abort
   " assert
   call s:assert.equals(getline(1, '$'), ['printf("hello\n");'])
 endfunction
+
+" context_filetype.vim related problem
+function! s:suite.vim_uncomment_doesnt_remove_hash() abort
+  " set up
+  setlocal filetype=vim
+  call setline(1, ['" call foo#bar()'])
+  call s:set_context(s:NORMAL_MODE_CONTEXT, {
+  \ 'filetype': 'vim',
+  \ 'context_filetype': 'vim',
+  \})
+
+  " execute
+  call s:dollarpos.uncomment()
+
+  " assert
+  call s:assert.equals(getline(1, '$'), [''])
+endfunction
+
+function! s:suite.c_uncomment_doesnt_remove_hash() abort
+  " set up
+  setlocal filetype=c
+  call setline(1, ['// foo() # bar()'])
+  call s:set_context(s:NORMAL_MODE_CONTEXT, {
+  \ 'filetype': 'c',
+  \ 'context_filetype': 'c',
+  \})
+
+  " execute
+  call s:dollarpos.uncomment()
+
+  " assert
+  call s:assert.equals(getline(1, '$'), [''])
+endfunction


### PR DESCRIPTION
Fix #126 

unless`b:caw_search_possible_comments` is defined and non-zero,
don't search possible comments by calling context_filetype.vim .

Curently only `javascript` and `typescript` sets `let b:caw_search_possible_comments = 1`. #91 