### PR TITLE
Enable uncomment when nvim-treesitter is used

### DIFF
--- a/autoload/caw/actions/traits/comment_detectable.vim
+++ b/autoload/caw/actions/traits/comment_detectable.vim
@@ -38,6 +38,7 @@ function! s:comment_detectable.get_commented_col(lnum, needle, ignore_syngroup) 
       break
     endif
     if a:ignore_syngroup || self.has_syntax('Comment$', a:lnum, idx + 1)
+          \ || (has('nvim-0.5.0') && luaeval("require'caw'.has_syntax(_A[1], _A[2])", [a:lnum, idx + 1]))
       break
     endif
     let start = idx + 1

--- a/lua/caw.lua
+++ b/lua/caw.lua
@@ -1,0 +1,34 @@
+local languages = {
+  cs = 'c_sharp',
+  javascriptreact = 'jsx',
+  sh = 'bash',
+  typescriptreact = 'tsx',
+}
+
+local M = {}
+
+function M.has_syntax(lnum, col)
+  local col = col - 1
+  local bufnr = vim.api.nvim_get_current_buf()
+  local filetype = vim.api.nvim_buf_get_option(bufnr, 'ft')
+  local lang = languages[filetype] or filetype
+  local query = require'vim.treesitter.query'.get_query(lang, 'highlights')
+  local tstree = vim.treesitter.get_parser(bufnr, lang):parse()
+  local tsnode = tstree:root()
+
+  for _, match in query:iter_matches(tsnode, bufnr, lnum - 1, lnum) do
+    for id, node in pairs(match) do
+      local _, start_col, _, end_col = node:range()
+      local name = query.captures[id]
+      local highlight = vim.treesitter.highlighter.hl_map[name]
+
+      if col >= start_col and col < end_col and string.match(highlight, 'Comment') then
+        return true
+      end
+    end
+  end
+
+  return false
+end
+
+return M


### PR DESCRIPTION
Resolve #149 
This PR supports uncommenting when [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) is used. The syntaxes of Vim that use `:syntax` is not used in Treesitter, so `Comment` is not defined and uncommenting fails. In this PR, the syntaxes are checked by Treesitter.

ref: https://github.com/neovim/neovim/blob/6312792d8a6a7d293661d33d440343d4cc6e0e6e/runtime/doc/treesitter.txt