### PR TITLE
Fix treesitter errors

### DIFF
--- a/lua/caw.lua
+++ b/lua/caw.lua
@@ -12,7 +12,10 @@ function M.has_syntax(lnum, col)
   local bufnr = vim.api.nvim_get_current_buf()
   local filetype = vim.api.nvim_buf_get_option(bufnr, 'ft')
   local lang = languages[filetype] or filetype
-  local query = require'vim.treesitter.query'.get_query(lang, 'highlights')
+  if not require"vim.treesitter.language".require_language(lang, nil, true) then
+    return false
+  end
+  local query = require"vim.treesitter.query".get_query(lang, "highlights")
   local tstree = vim.treesitter.get_parser(bufnr, lang):parse()
   local tsnode = tstree:root()
 

--- a/lua/caw.lua
+++ b/lua/caw.lua
@@ -16,7 +16,7 @@ function M.has_syntax(lnum, col)
     return false
   end
   local query = require"vim.treesitter.query".get_query(lang, "highlights")
-  local tstree = vim.treesitter.get_parser(bufnr, lang):parse()
+  local tstree = vim.treesitter.get_parser(bufnr, lang):parse()[1]
   local tsnode = tstree:root()
 
   for _, match in query:iter_matches(tsnode, bufnr, lnum - 1, lnum) do


### PR DESCRIPTION
## Problem

The following error occurs if treesitter parser does not exist for the language.
```
[Vim(if):E5108: Error executing lua ...nux64/share/nvim/runtime/lua/vim/treesitter/language.lua:25: no parser for 'lua' language, see :help treesitter-parsers]::[function caw#keymapping_stub[63]..18[3]..23[2]..20[2]..10[4]..21, line 9]
```

fix: https://github.com/tyru/caw.vim/issues/158

### reproduce steps

version: Neovim nightly (NVIM v0.5.0-dev+998-g48caf1df8)

```
nvim -u NORC --cmd "source minimal.vim"
```

minimal.vim
```vim
set runtimepath+=/path/to/caw.vim
syntax enable
filetype plugin on
set filetype=lua
call append(0, 'local a = "--"')
normal! gg
call feedkeys('gcc', 'm')
```

## Solution

- https://github.com/tyru/caw.vim/commit/160f423e1df33722a2d2b485335f955f1e165afe Check whether the parser exists
- https://github.com/tyru/caw.vim/commit/1b221f773f8638c1c9c2b8013a2bff2c4158ddd0 Follow to treesitter interface update https://github.com/neovim/neovim/pull/13252
