### PR TITLE
Add initial support for Vim9 script 

### DIFF
--- a/after/ftplugin/vim/caw.vim
+++ b/after/ftplugin/vim/caw.vim
@@ -1,7 +1,10 @@
 " vim:foldmethod=marker:fen:
 scriptencoding utf-8
 
-let b:caw_oneline_comment = '"'
+function! s:is_vim9line(lnum) abort
+  return search('\C\m^\s*vim9s\%[cript]\>', 'bnWz') >= 1
+endfunction
+let b:caw_oneline_comment = { lnum -> s:is_vim9line(lnum) ? '#' : '"' }
 function! s:linecont_sp(lnum) abort
   return getline(a:lnum) =~# '^\s*\\' ? '' : ' '
 endfunction

--- a/test/comments/oneline.vim
+++ b/test/comments/oneline.vim
@@ -19,7 +19,7 @@ endfunction
 
 function! s:suite.can_load_vim_ftplugin() abort
   setlocal filetype=vim
-  call s:assert.equals(b:caw_oneline_comment, '"')
+  call s:assert.is_function(b:caw_oneline_comment)
 endfunction
 
 function! s:suite.get_comments() abort


### PR DESCRIPTION
If the cursor line is after a `:vim9script` line, use `#` instead of `"`.