### PR TITLE
Add TLA+ support

### DIFF
--- a/after/ftplugin/tla/caw.vim
+++ b/after/ftplugin/tla/caw.vim
@@ -1,0 +1,16 @@
+" vim:foldmethod=marker:fen:
+scriptencoding utf-8
+
+let b:caw_oneline_comment = '\*'
+let b:caw_wrap_oneline_comment = ['(*', '*)']
+let b:caw_wrap_multiline_comment = {'right': '*)', 'bottom': '*', 'left': '(*', 'top': '*'}
+
+if !exists('b:did_caw_ftplugin')
+  if exists('b:undo_ftplugin')
+    let b:undo_ftplugin .= ' | '
+  else
+    let b:undo_ftplugin = ''
+  endif
+  let b:undo_ftplugin .= 'unlet! b:caw_oneline_comment b:caw_wrap_oneline_comment b:caw_wrap_multiline_comment b:did_caw_ftplugin'
+  let b:did_caw_ftplugin = 1
+endif

--- a/macros/generate-ftplugins.vim
+++ b/macros/generate-ftplugins.vim
@@ -278,6 +278,7 @@ function! s:oneline() abort
   \   'texmf': '%',
   \   'tf': ';',
   \   'tidy': '#',
+  \   'tla': '\*',
   \   'tli': '#',
   \   'tmux': '#',
   \   'toml': '#',
@@ -404,6 +405,7 @@ function! s:wrap_oneline() abort
   \   'systemverilog': ['/*', '*/'],
   \   'tads': ['/*', '*/'],
   \   'tsalt': ['/*', '*/'],
+  \   'tla': ['(*', '*)'],
   \   'tsx': ['{/*', '*/}'],
   \   'typescript': ['/*', '*/'],
   \   'typescriptreact': ['/*', '*/'],
@@ -426,6 +428,7 @@ function! s:wrap_multiline() abort
   \   'racket': {'left': '#|', 'top': '#', 'bottom': '#', 'right': '|#'},
   \   'ruby': {'left': '#', 'top': '#', 'bottom': '#', 'right': '#'},
   \   'swig': {'left': '/*', 'top': '*', 'bottom': '*', 'right': '*/'},
+  \   'tla': {'left': '(*', 'top': '*', 'bottom': '*', 'right': '*)'},
   \}
 endfunction
 


### PR DESCRIPTION
Reference: https://tlaplus.arnevogel.com/basics/comments/

Box comments are also very useful, because they are pretty-printed when exporting the TLA+ specification to LaTeX.