### PR TITLE
Fix uncommentout error in treesitter

### DIFF
--- a/lua/caw.lua
+++ b/lua/caw.lua
@@ -23,9 +23,10 @@ function M.has_syntax(lnum, col)
     for id, node in pairs(match) do
       local _, start_col, _, end_col = node:range()
       local name = query.captures[id]
-      local highlight = vim.treesitter.highlighter.hl_map[name]
 
-      if col >= start_col and col < end_col and string.match(highlight, 'Comment') then
+      local is_comment = vim.treesitter.highlighter.hl_map == nil or string.match(vim.treesitter.highlighter.hl_map[name], 'Comment')
+
+      if col >= start_col and col < end_col and is_comment then
         return true
       end
     end


### PR DESCRIPTION
When uncommenting while applying treesitter, an error occurred when `vim.treesitter.highlighter.hl_map` was nil.
Fixed it so that if it is nil, it is judged to be in a comment and processed.